### PR TITLE
Parse `noSolution` status from CPLEXShell and CPLEXDirect solvers correctly

### DIFF
--- a/pyomo/solvers/plugins/solvers/CPLEX.py
+++ b/pyomo/solvers/plugins/solvers/CPLEX.py
@@ -510,7 +510,7 @@ class CPLEXSHELL(ILMLicensedSystemCallSolver):
 
         for line in output.split("\n"):
             tokens = re.split('[ \t]+',line.strip())
-            if len(tokens) > 3 and tokens[0] == "CPLEX" and tokens[1] == "Error":
+            if len(tokens) > 3 and ("CPLEX", "Error") in {tuple(tokens[0:2]), tuple(tokens[1:3])}:
             # IMPT: See below - cplex can generate an error line and then terminate fine, e.g., in CPLEX 12.1.
             #       To handle these cases, we should be specifying some kind of termination criterion always
             #       in the course of parsing a log file (we aren't doing so currently - just in some conditions).
@@ -518,6 +518,8 @@ class CPLEXSHELL(ILMLicensedSystemCallSolver):
                 results.solver.error = " ".join(tokens)
             elif len(tokens) >= 3 and tokens[0] == "ILOG" and tokens[1] == "CPLEX":
                 cplex_version = tokens[2].rstrip(',')
+            elif len(tokens) >= 3 and tokens[1] == "Version":
+                cplex_version = tokens[3]
             elif len(tokens) >= 3 and tokens[0] == "Variables":
                 if results.problem.number_of_variables is None: # CPLEX 11.2 and subsequent versions have two Variables sections in the log file output.
                     results.problem.number_of_variables = int(tokens[2])
@@ -532,9 +534,9 @@ class CPLEXSHELL(ILMLicensedSystemCallSolver):
             elif len(tokens) >= 3 and tokens[0] == "Nonzeros":
                 if results.problem.number_of_nonzeros is None: # CPLEX 11.2 and subsequent has two Nonzeros sections.
                     results.problem.number_of_nonzeros = int(tokens[2])
-            elif len(tokens) >= 5 and tokens[4] == "MINIMIZE":
+            elif (len(tokens) >= 5 and tokens[4] == "MINIMIZE") or (len(tokens) >= 4 and tokens[3] == 'Minimize'):
                 results.problem.sense = ProblemSense.minimize
-            elif len(tokens) >= 5 and tokens[4] == "MAXIMIZE":
+            elif (len(tokens) >= 5 and tokens[4] == "MAXIMIZE") or (len(tokens) >= 4 and tokens[3] == 'Maximize'):
                 results.problem.sense = ProblemSense.maximize
             elif len(tokens) >= 4 and tokens[0] == "Solution" and tokens[1] == "time" and tokens[2] == "=":
                 # technically, I'm not sure if this is CPLEX user time or user+system - CPLEX doesn't appear
@@ -565,6 +567,9 @@ class CPLEXSHELL(ILMLicensedSystemCallSolver):
                 # handle processing when the time limit has been exceeded, and we have a feasible solution.
                 results.solver.status = SolverStatus.ok
                 results.solver.termination_condition = TerminationCondition.maxTimeLimit
+                results.solver.termination_message = ' '.join(tokens)
+            elif len(tokens) >= 6 and tokens[0] == "MIP" and tuple(tokens[5:]) == ('no', 'integer', 'solution.'):
+                results.solver.termination_condition = TerminationCondition.noSolution
                 results.solver.termination_message = ' '.join(tokens)
             elif len(tokens) >= 10 and tokens[0] == "Current" and tokens[1] == "MIP" and tokens[2] == "best" and tokens[3] == "bound":
                 self._best_bound = float(tokens[5])

--- a/pyomo/solvers/plugins/solvers/CPLEX.py
+++ b/pyomo/solvers/plugins/solvers/CPLEX.py
@@ -516,6 +516,13 @@ class CPLEXSHELL(ILMLicensedSystemCallSolver):
             #       in the course of parsing a log file (we aren't doing so currently - just in some conditions).
                 results.solver.status=SolverStatus.error
                 results.solver.error = " ".join(tokens)
+
+                # Find the first token that starts with an integer, and strip non-integer characters for the return code
+                rc_token = next((token for token in tokens if re.match(r'\d', token)), None)
+                if rc_token:
+                    results.solver.return_code = int(re.sub(r'[^\d]', '', rc_token))
+                else:
+                    results.solver.return_code = 0
             elif len(tokens) >= 3 and tokens[0] == "ILOG" and tokens[1] == "CPLEX":
                 cplex_version = tokens[2].rstrip(',')
             elif len(tokens) >= 3 and tokens[1] == "Version":

--- a/pyomo/solvers/plugins/solvers/CPLEX.py
+++ b/pyomo/solvers/plugins/solvers/CPLEX.py
@@ -514,7 +514,23 @@ class CPLEXSHELL(ILMLicensedSystemCallSolver):
             # IMPT: See below - cplex can generate an error line and then terminate fine, e.g., in CPLEX 12.1.
             #       To handle these cases, we should be specifying some kind of termination criterion always
             #       in the course of parsing a log file (we aren't doing so currently - just in some conditions).
-                results.solver.status=SolverStatus.error
+                if (
+                    results.solver.status == SolverStatus.ok
+                    and results.solver.termination_condition
+                    in {
+                        TerminationCondition.optimal,
+                        TerminationCondition.infeasible,
+                        TerminationCondition.maxTimeLimit,
+                        TerminationCondition.noSolution,
+                        TerminationCondition.unbounded,
+                    }
+                ):
+                    # If we have already determined the termination condition, reduce it to a warning.
+                    # This is to be consistent with the code in the rest of this method that downgrades an error to a
+                    # warning upon determining these termination conditions.
+                    results.solver.status = SolverStatus.warning
+                else:
+                    results.solver.status = SolverStatus.error
                 results.solver.error = " ".join(tokens)
 
                 # Find the first token that starts with an integer, and strip non-integer characters for the return code

--- a/pyomo/solvers/plugins/solvers/CPLEX.py
+++ b/pyomo/solvers/plugins/solvers/CPLEX.py
@@ -518,11 +518,11 @@ class CPLEXSHELL(ILMLicensedSystemCallSolver):
                 results.solver.error = " ".join(tokens)
 
                 # Find the first token that starts with an integer, and strip non-integer characters for the return code
-                rc_token = next((token for token in tokens if re.match(r'\d', token)), None)
-                if rc_token:
-                    results.solver.return_code = int(re.sub(r'[^\d]', '', rc_token))
+                error_code_token = next((token for token in tokens if re.match(r'\d', token)), None)
+                if error_code_token:
+                    results.solver.return_code = int(re.sub(r'[^\d]', '', error_code_token))
                 else:
-                    results.solver.return_code = 0
+                    results.solver.return_code = None
             elif len(tokens) >= 3 and tokens[0] == "ILOG" and tokens[1] == "CPLEX":
                 cplex_version = tokens[2].rstrip(',')
             elif len(tokens) >= 3 and tokens[1] == "Version":

--- a/pyomo/solvers/plugins/solvers/cplex_direct.py
+++ b/pyomo/solvers/plugins/solvers/cplex_direct.py
@@ -562,9 +562,9 @@ class CPLEXDirect(DirectSolver):
         } or self._error_code == self._cplex.exceptions.error_codes.CPXERR_NO_SOLN:
             # CPLEX doesn't have a solution status for `noSolution` so we assume this from the combination of
             # maxTimeLimit + infeasible (instead of a generic `TerminationCondition.error`).
-            self.results.solver.status = SolverStatus.error
+            self.results.solver.status = SolverStatus.warning
             self.results.solver.termination_condition = TerminationCondition.noSolution
-            soln.status = SolutionStatus.error
+            soln.status = SolutionStatus.unknown
         else:
             self.results.solver.status = SolverStatus.error
             self.results.solver.termination_condition = TerminationCondition.error

--- a/pyomo/solvers/plugins/solvers/cplex_direct.py
+++ b/pyomo/solvers/plugins/solvers/cplex_direct.py
@@ -181,13 +181,13 @@ class CPLEXDirect(DirectSolver):
                         raise
                     opt_cmd.set(float(option))
 
-            self._rc = None
+            self._error_code = None
             t0 = time.time()
 
             try:
                 self._solver_model.solve()
             except self._cplex.exceptions.CplexSolverError as e:
-                self._rc = e.args[2]  # See cplex.exceptions.error_codes
+                self._error_code = e.args[2]  # See cplex.exceptions.error_codes
 
             t1 = time.time()
             self._wallclock_time = t1 - t0
@@ -556,7 +556,7 @@ class CPLEXDirect(DirectSolver):
         elif status in {
             rtn_codes.MIP_time_limit_infeasible,
             rtn_codes.MIP_dettime_limit_infeasible,
-        } or self._rc == self._cplex.exceptions.error_codes.CPXERR_NO_SOLN:
+        } or self._error_code == self._cplex.exceptions.error_codes.CPXERR_NO_SOLN:
             # CPLEX doesn't have a solution status for `noSolution` so we assume this from the combination of
             # maxTimeLimit + infeasible (instead of a generic `TerminationCondition.error`).
             self.results.solver.status = SolverStatus.error
@@ -567,7 +567,7 @@ class CPLEXDirect(DirectSolver):
             self.results.solver.termination_condition = TerminationCondition.error
             soln.status = SolutionStatus.error
 
-        self.results.solver.return_code = self._rc
+        self.results.solver.return_code = self._error_code
         self.results.solver.termination_message = cpxprob.solution.get_status_string(status)
 
         if cpxprob.objective.get_sense() == cpxprob.objective.sense.minimize:

--- a/pyomo/solvers/plugins/solvers/cplex_direct.py
+++ b/pyomo/solvers/plugins/solvers/cplex_direct.py
@@ -556,6 +556,9 @@ class CPLEXDirect(DirectSolver):
         elif status in {
             rtn_codes.MIP_time_limit_infeasible,
             rtn_codes.MIP_dettime_limit_infeasible,
+            rtn_codes.node_limit_infeasible,
+            rtn_codes.mem_limit_infeasible,
+            rtn_codes.MIP_abort_infeasible,
         } or self._error_code == self._cplex.exceptions.error_codes.CPXERR_NO_SOLN:
             # CPLEX doesn't have a solution status for `noSolution` so we assume this from the combination of
             # maxTimeLimit + infeasible (instead of a generic `TerminationCondition.error`).

--- a/pyomo/solvers/plugins/solvers/cplex_direct.py
+++ b/pyomo/solvers/plugins/solvers/cplex_direct.py
@@ -180,9 +180,15 @@ class CPLEXDirect(DirectSolver):
                     if not _is_numeric(option):
                         raise
                     opt_cmd.set(float(option))
-            
+
+            self._rc = None
             t0 = time.time()
-            self._solver_model.solve()
+
+            try:
+                self._solver_model.solve()
+            except self._cplex.exceptions.CplexSolverError as e:
+                self._rc = e.args[2]  # See cplex.exceptions.error_codes
+
             t1 = time.time()
             self._wallclock_time = t1 - t0
         finally:
@@ -550,8 +556,8 @@ class CPLEXDirect(DirectSolver):
         elif status in {
             rtn_codes.MIP_time_limit_infeasible,
             rtn_codes.MIP_dettime_limit_infeasible,
-        }:
-            # CPLEX doesn't have an exit status for `noSolution` so we assume this from the combination of
+        } or self._rc == self._cplex.exceptions.error_codes.CPXERR_NO_SOLN:
+            # CPLEX doesn't have a solution status for `noSolution` so we assume this from the combination of
             # maxTimeLimit + infeasible (instead of a generic `TerminationCondition.error`).
             self.results.solver.status = SolverStatus.error
             self.results.solver.termination_condition = TerminationCondition.noSolution
@@ -561,6 +567,7 @@ class CPLEXDirect(DirectSolver):
             self.results.solver.termination_condition = TerminationCondition.error
             soln.status = SolutionStatus.error
 
+        self.results.solver.return_code = self._rc
         self.results.solver.termination_message = cpxprob.solution.get_status_string(status)
 
         if cpxprob.objective.get_sense() == cpxprob.objective.sense.minimize:

--- a/pyomo/solvers/plugins/solvers/cplex_direct.py
+++ b/pyomo/solvers/plugins/solvers/cplex_direct.py
@@ -547,6 +547,15 @@ class CPLEXDirect(DirectSolver):
             self.results.solver.status = SolverStatus.aborted
             self.results.solver.termination_condition = TerminationCondition.maxTimeLimit
             soln.status = SolutionStatus.stoppedByLimit
+        elif status in {
+            rtn_codes.MIP_time_limit_infeasible,
+            rtn_codes.MIP_dettime_limit_infeasible,
+        }:
+            # CPLEX doesn't have an exit status for `noSolution` so we assume this from the combination of
+            # maxTimeLimit + infeasible (instead of a generic `TerminationCondition.error`).
+            self.results.solver.status = SolverStatus.error
+            self.results.solver.termination_condition = TerminationCondition.noSolution
+            soln.status = SolutionStatus.error
         else:
             self.results.solver.status = SolverStatus.error
             self.results.solver.termination_condition = TerminationCondition.error

--- a/pyomo/solvers/plugins/solvers/cplex_direct.py
+++ b/pyomo/solvers/plugins/solvers/cplex_direct.py
@@ -561,6 +561,8 @@ class CPLEXDirect(DirectSolver):
             self.results.solver.termination_condition = TerminationCondition.error
             soln.status = SolutionStatus.error
 
+        self.results.solver.termination_message = cpxprob.solution.get_status_string(status)
+
         if cpxprob.objective.get_sense() == cpxprob.objective.sense.minimize:
             self.results.problem.sense = minimize
         elif cpxprob.objective.get_sense() == cpxprob.objective.sense.maximize:

--- a/pyomo/solvers/tests/checks/test_CPLEXDirect.py
+++ b/pyomo/solvers/tests/checks/test_CPLEXDirect.py
@@ -115,6 +115,24 @@ class CPLEXDirectTests(unittest.TestCase):
 
     @unittest.skipIf(not cplexpy_available,
                      "The 'cplex' python bindings are not available")
+    def test_no_solution_mip(self):
+        model = ConcreteModel()
+        model.X = Var(within=Binary)
+        model.C2 = Constraint(expr=model.X >= 2)
+        model.O = Objective(expr=model.X)
+
+        with SolverFactory("cplex", solver_io="python") as opt:
+            # Set the `options` such that CPLEX cannot determine the problem as infeasible within the time allowed
+            opt.options['timelimit'] = 0
+            opt.options['preprocessing_presolve'] = 0
+
+            results = opt.solve(model, load_solutions=False)
+
+            self.assertEqual(results.solver.termination_condition,
+                             TerminationCondition.noSolution)
+
+    @unittest.skipIf(not cplexpy_available,
+                     "The 'cplex' python bindings are not available")
     def test_unbounded_mip(self):
         with SolverFactory("cplex", solver_io="python") as opt:
 

--- a/pyomo/solvers/tests/checks/test_CPLEXDirect.py
+++ b/pyomo/solvers/tests/checks/test_CPLEXDirect.py
@@ -120,8 +120,8 @@ class CPLEXDirectTests(unittest.TestCase):
         model.S = RangeSet(0, 9)
         model.P = list(range(10))
         model.X = Var(model.S, within=Binary)
-        model.C = Constraint(expr=summation(model.X) == 1)
-        model.C = Constraint(expr=model.X[0] >= 2)
+        model.C1 = Constraint(expr=summation(model.X) == 1)
+        model.C2 = Constraint(expr=model.X[0] >= 2)
         model.O = Objective(expr=sum_product(model.P, model.X), sense=minimize)
 
         with SolverFactory("cplex", solver_io="python") as opt:

--- a/pyomo/solvers/tests/checks/test_CPLEXDirect.py
+++ b/pyomo/solvers/tests/checks/test_CPLEXDirect.py
@@ -121,7 +121,8 @@ class CPLEXDirectTests(unittest.TestCase):
         model.P = list(range(10))
         model.X = Var(model.S, within=Binary)
         model.C = Constraint(expr=summation(model.X) == 1)
-        model.O = Objective(expr=sum_product(model.P, model.X))
+        model.C = Constraint(expr=model.X[0] >= 2)
+        model.O = Objective(expr=sum_product(model.P, model.X), sense=minimize)
 
         with SolverFactory("cplex", solver_io="python") as opt:
             # Set the `options` such that CPLEX cannot determine the problem as infeasible within the time allowed
@@ -130,7 +131,7 @@ class CPLEXDirectTests(unittest.TestCase):
             opt.options['simplex_limits_iterations'] = 1
             opt.options['mip_limits_nodes'] = 1
 
-            results = opt.solve(model, load_solutions=False)
+            results = opt.solve(model)
 
             self.assertEqual(results.solver.termination_condition,
                              TerminationCondition.noSolution)

--- a/pyomo/solvers/tests/checks/test_CPLEXDirect.py
+++ b/pyomo/solvers/tests/checks/test_CPLEXDirect.py
@@ -117,14 +117,18 @@ class CPLEXDirectTests(unittest.TestCase):
                      "The 'cplex' python bindings are not available")
     def test_no_solution_mip(self):
         model = ConcreteModel()
-        model.X = Var(within=Binary)
-        model.C2 = Constraint(expr=model.X >= 2)
-        model.O = Objective(expr=model.X)
+        model.S = RangeSet(0, 9)
+        model.P = list(range(10))
+        model.X = Var(model.S, within=Binary)
+        model.C = Constraint(expr=summation(model.X) == 1)
+        model.O = Objective(expr=sum_product(model.P, model.X))
 
         with SolverFactory("cplex", solver_io="python") as opt:
             # Set the `options` such that CPLEX cannot determine the problem as infeasible within the time allowed
             opt.options['timelimit'] = 0
             opt.options['preprocessing_presolve'] = 0
+            opt.options['simplex_limits_iterations'] = 1
+            opt.options['mip_limits_nodes'] = 1
 
             results = opt.solve(model, load_solutions=False)
 

--- a/pyomo/solvers/tests/checks/test_cplex.py
+++ b/pyomo/solvers/tests/checks/test_cplex.py
@@ -276,7 +276,7 @@ CPLEX>"""
             f.write(log_file_text)
 
         results = CPLEXSHELL.process_logfile(self.solver)
-        self.assertEqual(results.solver.status, SolverStatus.error)
+        self.assertEqual(results.solver.status, SolverStatus.warning)
         self.assertEqual(
             results.solver.termination_condition, TerminationCondition.noSolution
         )
@@ -300,7 +300,7 @@ CPLEX>"""
             f.write(log_file_text)
 
         results = CPLEXSHELL.process_logfile(self.solver)
-        self.assertEqual(results.solver.status, SolverStatus.error)
+        self.assertEqual(results.solver.status, SolverStatus.warning)
         self.assertEqual(
             results.solver.termination_condition, TerminationCondition.infeasible
         )
@@ -324,7 +324,7 @@ CPLEX>"""
             f.write(log_file_text)
 
         results = CPLEXSHELL.process_logfile(self.solver)
-        self.assertEqual(results.solver.status, SolverStatus.error)
+        self.assertEqual(results.solver.status, SolverStatus.warning)
         self.assertEqual(
             results.solver.termination_condition, TerminationCondition.infeasible
         )

--- a/pyomo/solvers/tests/checks/test_cplex.py
+++ b/pyomo/solvers/tests/checks/test_cplex.py
@@ -309,6 +309,29 @@ CPLEX>"""
         )
         self.assertEqual(results.solver.return_code, 1217)
 
+    def test_log_file_shows_presolve_infeasible(self):
+        log_file_text = """
+Infeasibility row 'c_e_x18_':  0  = -1.
+Presolve time = 0.00 sec. (0.00 ticks)
+Presolve - Infeasible.
+Solution time =    0.00 sec.
+Deterministic time = 0.00 ticks  (0.61 ticks/sec)
+CPLEX> CPLEX Error  1217: No solution exists.
+No file written.
+CPLEX>"""
+
+        with open(self.solver._log_file, "w") as f:
+            f.write(log_file_text)
+
+        results = CPLEXSHELL.process_logfile(self.solver)
+        self.assertEqual(results.solver.status, SolverStatus.error)
+        self.assertEqual(
+            results.solver.termination_condition, TerminationCondition.infeasible
+        )
+        self.assertEqual(
+            results.solver.termination_message, "Presolve - Infeasible."
+        )
+        self.assertEqual(results.solver.return_code, 1217)
 
 if __name__ == "__main__":
     unittest.main()

--- a/pyomo/solvers/tests/checks/test_cplex.py
+++ b/pyomo/solvers/tests/checks/test_cplex.py
@@ -14,7 +14,8 @@ import pyutilib
 import pyutilib.th as unittest
 
 from pyomo.core import Binary, ConcreteModel, Constraint, Objective, Var, Integers, RangeSet, minimize, quicksum, Suffix
-from pyomo.opt import ProblemFormat, convert_problem, SolverFactory, BranchDirection
+from pyomo.opt import (BranchDirection, ProblemFormat, SolverFactory,
+                       SolverStatus, TerminationCondition, convert_problem)
 from pyomo.solvers.plugins.solvers.CPLEX import CPLEXSHELL, MockCPLEX, _validate_file_name, ORDFileSchema
 
 
@@ -248,6 +249,65 @@ class CPLEXShellSolvePrioritiesFile(unittest.TestCase):
                 priorities_file = ord_file.read()
 
         assert priorities_file == provided_priorities_file
+
+
+class TestCPLEXSHELLProcessLogfile(unittest.TestCase):
+    def setUp(self):
+        solver = MockCPLEX()
+        solver._log_file = pyutilib.services.TempfileManager.create_tempfile(
+            suffix=".log"
+        )
+        self.solver = solver
+
+    def tearDown(self):
+        pyutilib.services.TempfileManager.clear_tempfiles()
+
+    def test_log_file_shows_no_solution(self):
+        log_file_text = """
+MIP - Time limit exceeded, no integer solution.
+Current MIP best bound =  0.0000000000e+00 (gap is infinite)
+Solution time =    0.00 sec.  Iterations = 0  Nodes = 0
+Deterministic time = 0.00 ticks  (0.20 ticks/sec)
+
+CPLEX> CPLEX Error  1217: No solution exists.
+No file written.
+CPLEX>"""
+        with open(self.solver._log_file, "w") as f:
+            f.write(log_file_text)
+
+        results = CPLEXSHELL.process_logfile(self.solver)
+        self.assertEqual(results.solver.status, SolverStatus.error)
+        self.assertEqual(
+            results.solver.termination_condition, TerminationCondition.noSolution
+        )
+        self.assertEqual(
+            results.solver.termination_message,
+            "MIP - Time limit exceeded, no integer solution.",
+        )
+        self.assertEqual(results.solver.return_code, 1217)
+
+    def test_log_file_shows_infeasible(self):
+        log_file_text = """
+MIP - Integer infeasible.
+Current MIP best bound =  0.0000000000e+00 (gap is infinite)
+Solution time =    0.00 sec.  Iterations = 0  Nodes = 0
+Deterministic time = 0.00 ticks  (0.20 ticks/sec)
+
+CPLEX> CPLEX Error  1217: No solution exists.
+No file written.
+CPLEX>"""
+        with open(self.solver._log_file, "w") as f:
+            f.write(log_file_text)
+
+        results = CPLEXSHELL.process_logfile(self.solver)
+        self.assertEqual(results.solver.status, SolverStatus.error)
+        self.assertEqual(
+            results.solver.termination_condition, TerminationCondition.infeasible
+        )
+        self.assertEqual(
+            results.solver.termination_message, "MIP - Integer infeasible."
+        )
+        self.assertEqual(results.solver.return_code, 1217)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Fixes

## Summary/Motivation:
Currently when CPLEX returns "No Solution", this isn't captured in any of the Pyomo solution or solver data objects. We can identify "No Solution" because when both of (1) max time limit is reached and (2) the model is infeasible occur.

## Changes proposed in this PR:

### `CPLEXDirect`
- Clean up the status codes in `_postsolve()` to use the actual CPLEX library constants
- Add new logic to handle `MIP_time_limit_infeasible` and `MIP_dettime_limit_infeasible` as indicating a solver `termination_condition` of `noSolution`
- Get the solver return code if possible from any `CplexSolverError`s (but don't add this to the returned `Bunch` due to downstream code raising `ApplicationError`s)
- Set `results.solver.return_code` and `results.solver.termination_message` using the available information

### `CPLEXSHELL`
- Fix `process_logfile()` for CPLEX 12.10 as it looks like IBM have updated the log file schema and is no longer being parsed correctly
- Add new logic to handle `'no integer solution.'` in the log file as indicating a solver `termination_condition` of `noSolution`
- Get the solver return code if possible from any `CPLEX Error` lines in the log file

### Legal Acknowledgement

By contributing to this software project, I agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
