### PR TITLE
MIP Solution Limit fixes

### DIFF
--- a/pyomo/solvers/plugins/solvers/CPLEX.py
+++ b/pyomo/solvers/plugins/solvers/CPLEX.py
@@ -701,7 +701,7 @@ class CPLEXSHELL(ILMLicensedSystemCallSolver):
 
         INPUT = open(self._soln_file, "r")
         results.problem.number_of_objectives=1
-        time_limit_exceeded = False
+        user_limit_exceeded = False
         mip_problem=False
         for line in INPUT:
             line = line.strip()
@@ -829,16 +829,16 @@ class CPLEXSHELL(ILMLicensedSystemCallSolver):
                 elif solution_status in ["infeasible"]:
                     soln.status = SolutionStatus.infeasible
                     soln.gap = None
-                elif solution_status in ["time limit exceeded"]:
+                elif solution_status in ["time limit exceeded", "solution limit exceeded"]:
                     # we need to know if the solution is primal feasible, and if it is, set the solution status accordingly.
                     # for now, just set the flag so we can trigger the logic when we see the primalFeasible keyword.
-                    time_limit_exceeded = True
+                    user_limit_exceeded = True
             elif tokens[0].startswith("MIPNodes"):
                 if mip_problem:
                     n = eval(eval((" ".join(tokens).split('=')[1]).strip()).lstrip("\"").rstrip("\""))
                     results.solver.statistics.branch_and_bound.number_of_created_subproblems=n
                     results.solver.statistics.branch_and_bound.number_of_bounded_subproblems=n
-            elif tokens[0].startswith("primalFeasible") and (time_limit_exceeded is True):
+            elif tokens[0].startswith("primalFeasible") and user_limit_exceeded:
                 primal_feasible = int(((" ".join(tokens).split('=')[1]).strip()).lstrip("\"").rstrip("\""))
                 if primal_feasible == 1:
                     soln.status = SolutionStatus.feasible

--- a/pyomo/solvers/plugins/solvers/CPLEX.py
+++ b/pyomo/solvers/plugins/solvers/CPLEX.py
@@ -701,7 +701,7 @@ class CPLEXSHELL(ILMLicensedSystemCallSolver):
 
         INPUT = open(self._soln_file, "r")
         results.problem.number_of_objectives=1
-        user_limit_exceeded = False
+        user_defined_limit_exceeded = False
         mip_problem=False
         for line in INPUT:
             line = line.strip()
@@ -832,13 +832,13 @@ class CPLEXSHELL(ILMLicensedSystemCallSolver):
                 elif solution_status in ["time limit exceeded", "solution limit exceeded"]:
                     # we need to know if the solution is primal feasible, and if it is, set the solution status accordingly.
                     # for now, just set the flag so we can trigger the logic when we see the primalFeasible keyword.
-                    user_limit_exceeded = True
+                    user_defined_limit_exceeded = True
             elif tokens[0].startswith("MIPNodes"):
                 if mip_problem:
                     n = eval(eval((" ".join(tokens).split('=')[1]).strip()).lstrip("\"").rstrip("\""))
                     results.solver.statistics.branch_and_bound.number_of_created_subproblems=n
                     results.solver.statistics.branch_and_bound.number_of_bounded_subproblems=n
-            elif tokens[0].startswith("primalFeasible") and user_limit_exceeded:
+            elif tokens[0].startswith("primalFeasible") and user_defined_limit_exceeded:
                 primal_feasible = int(((" ".join(tokens).split('=')[1]).strip()).lstrip("\"").rstrip("\""))
                 if primal_feasible == 1:
                     soln.status = SolutionStatus.feasible

--- a/pyomo/solvers/plugins/solvers/cplex_direct.py
+++ b/pyomo/solvers/plugins/solvers/cplex_direct.py
@@ -545,6 +545,14 @@ class CPLEXDirect(DirectSolver):
             self.results.solver.termination_condition = TerminationCondition.maxIterations
             soln.status = SolutionStatus.stoppedByLimit
         elif status in {
+            rtn_codes.solution_limit,
+            rtn_codes.node_limit_feasible,
+            rtn_codes.mem_limit_feasible
+        }:
+            self.results.solver.status = SolverStatus.aborted
+            self.results.solver.termination_condition = TerminationCondition.unknown
+            soln.status = SolutionStatus.stoppedByLimit
+        elif status in {
             rtn_codes.abort_time_limit,
             rtn_codes.abort_dettime_limit,
             rtn_codes.MIP_time_limit_feasible,

--- a/pyomo/solvers/tests/checks/test_CPLEXDirect.py
+++ b/pyomo/solvers/tests/checks/test_CPLEXDirect.py
@@ -244,5 +244,24 @@ class CPLEXDirectTests(unittest.TestCase):
             self.assertEqual(results.solution.status,
                              SolutionStatus.optimal)
 
+    @unittest.skipIf(not cplexpy_available,
+                     "The 'cplex' python bindings are not available")
+    def test_soln_limit_mip(self):
+        with SolverFactory("cplex", solver_io="python") as opt:
+            model = ConcreteModel()
+            model.X = Var(within=Binary)
+            model.C1 = Constraint(expr=model.X == 1)
+            model.O = Objective(expr=model.X)
+
+            opt.options['mip_limits_solutions'] = 1
+            results = opt.solve(model)
+
+            self.assertEqual(results.solver.status,
+                             SolverStatus.aborted)
+            self.assertEqual(results.solver.termination_condition,
+                             TerminationCondition.unknown)
+            self.assertEqual(model.solutions[0].status,
+                             SolutionStatus.stoppedByLimit)
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Fixes # .

## Summary/Motivation:
- The CPLEX LP and Direct solvers behave very differently when using the CPLEX parameter `
mip.limits.solutions` to control the termination of the model.


## Changes proposed in this PR:
- Return `soln.status = SolutionStatus.feasible` for the Shell solver if we are using this parameter rather than `SolutionStatus.error`. This is to be consistent with what would be returned for a time limit.
- Return `termination_condition = TerminationCondition.unknown` for the Direct solver rather than `error`

### Legal Acknowledgement

By contributing to this software project, I agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
