### PR TITLE
Fix CPLEX user interrupt

### DIFF
--- a/pyomo/solvers/plugins/solvers/cplex_direct.py
+++ b/pyomo/solvers/plugins/solvers/cplex_direct.py
@@ -679,6 +679,10 @@ class CPLEXDirect(DirectSolver):
             self.results.solver.status = SolverStatus.aborted
             self.results.solver.termination_condition = TerminationCondition.maxIterations
             soln.status = SolutionStatus.stoppedByLimit
+        elif status in {rtn_codes.MIP_abort_feasible}:
+            self.results.solver.status = SolverStatus.aborted
+            self.results.solver.termination_condition = TerminationCondition.userInterrupt
+            soln.status = SolutionStatus.feasible
         elif status in {
             rtn_codes.solution_limit,
             rtn_codes.node_limit_feasible,


### PR DESCRIPTION
## Fixes # .

## Summary/Motivation:
It could be perfectly reasonable for the user to terminate the solve (via a callback) and we would still want to load all the results and treat things as per optimality or the max timelimit had been reached. We are currently treating this scenario as a breaking failure in the optimisation.

## Changes proposed in this PR:
- Map `MIP_abort_feasible` correctly to a non-error code.