### PR TITLE
Parse cplex log to obtain warm start value, no. of solutions/constraints, solve times

### DIFF
--- a/pyomo/opt/results/solver.py
+++ b/pyomo/opt/results/solver.py
@@ -121,5 +121,5 @@ class SolverInformation(MapContainer):
         self.declare('root_node_processing_time', type=ScalarType.time)
         # Semantics: The total time spent processing the MIP search tree.
         self.declare('tree_processing_time', type=ScalarType.time)
-        # Semantics: The total time spent processing the MIP search tree.
+        # Semantics: The number of feasible solutions found.
         self.declare('n_solutions_found', type=ScalarType.int)

--- a/pyomo/opt/results/solver.py
+++ b/pyomo/opt/results/solver.py
@@ -117,3 +117,5 @@ class SolverInformation(MapContainer):
         self.declare('termination_message')
         self.declare('statistics', value=SolverStatistics(), active=False)
         self.declare('warm_start_objective_value', type=ScalarType.float)
+        # Semantics: The total time spent processing the root node.
+        self.declare('root_node_processing_time', type=ScalarType.time)

--- a/pyomo/opt/results/solver.py
+++ b/pyomo/opt/results/solver.py
@@ -119,3 +119,5 @@ class SolverInformation(MapContainer):
         self.declare('warm_start_objective_value', type=ScalarType.float)
         # Semantics: The total time spent processing the root node.
         self.declare('root_node_processing_time', type=ScalarType.time)
+        # Semantics: The total time spent processing the MIP search tree.
+        self.declare('tree_processing_time', type=ScalarType.time)

--- a/pyomo/opt/results/solver.py
+++ b/pyomo/opt/results/solver.py
@@ -121,3 +121,5 @@ class SolverInformation(MapContainer):
         self.declare('root_node_processing_time', type=ScalarType.time)
         # Semantics: The total time spent processing the MIP search tree.
         self.declare('tree_processing_time', type=ScalarType.time)
+        # Semantics: The total time spent processing the MIP search tree.
+        self.declare('n_solutions_found', type=ScalarType.int)

--- a/pyomo/opt/results/solver.py
+++ b/pyomo/opt/results/solver.py
@@ -116,3 +116,4 @@ class SolverInformation(MapContainer):
         # termination status.
         self.declare('termination_message')
         self.declare('statistics', value=SolverStatistics(), active=False)
+        self.declare('warm_start_objective_value', type=ScalarType.float)

--- a/pyomo/solvers/plugins/solvers/CPLEX.py
+++ b/pyomo/solvers/plugins/solvers/CPLEX.py
@@ -560,9 +560,9 @@ class CPLEXSHELL(ILMLicensedSystemCallSolver):
                 if results.problem.number_of_variables is None: # CPLEX 11.2 and subsequent versions have two Variables sections in the log file output.
                     results.problem.number_of_variables = int(tokens[2])
                 if len(tokens) >= 5 and "Nneg" in tokens[3]:
-                    results.problem.number_of_continuous_variables = int(tokens[4][:-1])  # remove trailing comma
+                    results.problem.number_of_continuous_variables = int(tokens[4].rstrip(','))
                 if len(tokens) >= 7 and "Binary" in tokens[5]:
-                    results.problem.number_of_binary_variables = int(tokens[6][:-1])  # remove trailing bracket
+                    results.problem.number_of_binary_variables = int(tokens[6].rstrip(']'))
             # In CPLEX 11 (and presumably before), there was only a single line output to
             # indicate the constriant count, e.g., "Linear constraints : 16 [Less: 7, Greater: 6, Equal: 3]".
             # In CPLEX 11.2 (or somewhere in between 11 and 11.2 - I haven't bothered to track it down

--- a/pyomo/solvers/plugins/solvers/CPLEX.py
+++ b/pyomo/solvers/plugins/solvers/CPLEX.py
@@ -562,7 +562,7 @@ class CPLEXSHELL(ILMLicensedSystemCallSolver):
                 if len(tokens) >= 5 and "Nneg" in tokens[3]:
                     results.problem.number_of_continuous_variables = int(tokens[4].rstrip(','))
                 if len(tokens) >= 7 and "Binary" in tokens[5]:
-                    results.problem.number_of_binary_variables = int(tokens[6].rstrip(']'))
+                    results.problem.number_of_binary_variables = int(tokens[6].rstrip('],'))
             # In CPLEX 11 (and presumably before), there was only a single line output to
             # indicate the constriant count, e.g., "Linear constraints : 16 [Less: 7, Greater: 6, Equal: 3]".
             # In CPLEX 11.2 (or somewhere in between 11 and 11.2 - I haven't bothered to track it down

--- a/pyomo/solvers/plugins/solvers/CPLEX.py
+++ b/pyomo/solvers/plugins/solvers/CPLEX.py
@@ -509,17 +509,17 @@ class CPLEXSHELL(ILMLicensedSystemCallSolver):
         self._gap = None
 
         # use regular expressions to use multi-line match patterns:
-        root_node_processing_time = re.findall(
-            r'Root node processing \(before b&c\):\n\s+Real time\s+=\s+(\d+\.\d+) sec', output
+        root_node_processing_time = re.search(
+            r'Root node processing.*:\n\s+Real time\s+=\s+(\d+\.\d+) sec', output
         )
         if root_node_processing_time:
-            results.solver.root_node_processing_time = float(root_node_processing_time[0])
+            results.solver.root_node_processing_time = float(root_node_processing_time.group(1))
 
-        tree_processing_time = re.findall(
-            r'[Parallel, \d+ threads b&c|Sequential b&c]:\n\s+Real time\s+=\s+(\d+\.\d+) sec', output
+        tree_processing_time = re.search(
+            r'(Parallel|Sequential).*\n\s+Real time\s+=\s+(\d+\.\d+) sec', output
         )
         if tree_processing_time:
-            results.solver.tree_processing_time = float(tree_processing_time[0])
+            results.solver.tree_processing_time = float(tree_processing_time.group(2))
 
         for line in output.split("\n"):
             tokens = re.split('[ \t]+',line.strip())

--- a/pyomo/solvers/plugins/solvers/CPLEX.py
+++ b/pyomo/solvers/plugins/solvers/CPLEX.py
@@ -510,10 +510,16 @@ class CPLEXSHELL(ILMLicensedSystemCallSolver):
 
         # use regular expressions to use multi-line match patterns:
         root_node_processing_time = re.findall(
-            r'Root node processing \(before b&c\):\n\s+Real time\s+=\s+(\d+\.\d+) sec\.', output
+            r'Root node processing \(before b&c\):\n\s+Real time\s+=\s+(\d+\.\d+) sec', output
         )
         if root_node_processing_time:
             results.solver.root_node_processing_time = float(root_node_processing_time[0])
+
+        tree_processing_time = re.findall(
+            r'[Parallel, \d+ threads b&c|Sequential b&c]:\n\s+Real time\s+=\s+(\d+\.\d+) sec', output
+        )
+        if tree_processing_time:
+            results.solver.tree_processing_time = float(tree_processing_time[0])
 
         for line in output.split("\n"):
             tokens = re.split('[ \t]+',line.strip())

--- a/pyomo/solvers/plugins/solvers/CPLEX.py
+++ b/pyomo/solvers/plugins/solvers/CPLEX.py
@@ -559,9 +559,9 @@ class CPLEXSHELL(ILMLicensedSystemCallSolver):
             elif len(tokens) >= 3 and tokens[0] == "Variables":
                 if results.problem.number_of_variables is None: # CPLEX 11.2 and subsequent versions have two Variables sections in the log file output.
                     results.problem.number_of_variables = int(tokens[2])
-                if "Nneg" in tokens[3]:
+                if len(tokens) >= 5 and "Nneg" in tokens[3]:
                     results.problem.number_of_continuous_variables = int(tokens[4][:-1])  # remove trailing comma
-                if "Binary" in tokens[5]:
+                if len(tokens) >= 6 and "Binary" in tokens[5]:
                     results.problem.number_of_binary_variables = int(tokens[6][:-1])  # remove trailing bracket
             # In CPLEX 11 (and presumably before), there was only a single line output to
             # indicate the constriant count, e.g., "Linear constraints : 16 [Less: 7, Greater: 6, Equal: 3]".

--- a/pyomo/solvers/plugins/solvers/CPLEX.py
+++ b/pyomo/solvers/plugins/solvers/CPLEX.py
@@ -620,7 +620,7 @@ class CPLEXSHELL(ILMLicensedSystemCallSolver):
                 results.solver.termination_message = ' '.join(tokens)
             elif len(tokens) >= 9 and tokens[0] == "MIP" and tokens[1] == "start" and tokens[7] == "objective":
                 results.solver.warm_start_objective_value = float(tokens[8][:-1])  # remove trailing full stop
-            elif len(tokens) >= 5 and tokens[0] == "Solution" and tokens[1] == "pool:" and tokens[3] in ["solution", "solutions"] and tokens[4] == "saved.":
+            elif len(tokens) >= 5 and tokens[0:2] == ["Solution", "pool:"] and tokens[3] in ["solution", "solutions"] and tokens[4] == "saved.":
                 results.solver.n_solutions_found = int(tokens[2])
             elif len(tokens) >= 10 and tokens[0] == "Current" and tokens[1] == "MIP" and tokens[2] == "best" and tokens[3] == "bound":
                 self._best_bound = float(tokens[5])

--- a/pyomo/solvers/plugins/solvers/CPLEX.py
+++ b/pyomo/solvers/plugins/solvers/CPLEX.py
@@ -601,6 +601,8 @@ class CPLEXSHELL(ILMLicensedSystemCallSolver):
             elif len(tokens) >= 6 and tokens[0] == "MIP" and tuple(tokens[5:]) == ('no', 'integer', 'solution.'):
                 results.solver.termination_condition = TerminationCondition.noSolution
                 results.solver.termination_message = ' '.join(tokens)
+            elif len(tokens) >= 9 and tokens[0] == "MIP" and tokens[1] == "start" and tokens[7] == "objective":
+                results.solver.warm_start_objective_value = float(tokens[8][:-1])  # remove trailing full stop
             elif len(tokens) >= 10 and tokens[0] == "Current" and tokens[1] == "MIP" and tokens[2] == "best" and tokens[3] == "bound":
                 self._best_bound = float(tokens[5])
                 self._gap = float(tokens[8].rstrip(','))

--- a/pyomo/solvers/plugins/solvers/CPLEX.py
+++ b/pyomo/solvers/plugins/solvers/CPLEX.py
@@ -508,6 +508,13 @@ class CPLEXSHELL(ILMLicensedSystemCallSolver):
         self._best_bound = None
         self._gap = None
 
+        # use regular expressions to use multi-line match patterns:
+        root_node_processing_time = re.findall(
+            r'Root node processing \(before b&c\):\n\s+Real time\s+=\s+(\d+\.\d+) sec\.', output
+        )
+        if root_node_processing_time:
+            results.solver.root_node_processing_time = float(root_node_processing_time[0])
+
         for line in output.split("\n"):
             tokens = re.split('[ \t]+',line.strip())
             if len(tokens) > 3 and ("CPLEX", "Error") in {tuple(tokens[0:2]), tuple(tokens[1:3])}:

--- a/pyomo/solvers/plugins/solvers/CPLEX.py
+++ b/pyomo/solvers/plugins/solvers/CPLEX.py
@@ -561,7 +561,7 @@ class CPLEXSHELL(ILMLicensedSystemCallSolver):
                     results.problem.number_of_variables = int(tokens[2])
                 if len(tokens) >= 5 and "Nneg" in tokens[3]:
                     results.problem.number_of_continuous_variables = int(tokens[4][:-1])  # remove trailing comma
-                if len(tokens) >= 6 and "Binary" in tokens[5]:
+                if len(tokens) >= 7 and "Binary" in tokens[5]:
                     results.problem.number_of_binary_variables = int(tokens[6][:-1])  # remove trailing bracket
             # In CPLEX 11 (and presumably before), there was only a single line output to
             # indicate the constriant count, e.g., "Linear constraints : 16 [Less: 7, Greater: 6, Equal: 3]".

--- a/pyomo/solvers/plugins/solvers/CPLEX.py
+++ b/pyomo/solvers/plugins/solvers/CPLEX.py
@@ -559,6 +559,10 @@ class CPLEXSHELL(ILMLicensedSystemCallSolver):
             elif len(tokens) >= 3 and tokens[0] == "Variables":
                 if results.problem.number_of_variables is None: # CPLEX 11.2 and subsequent versions have two Variables sections in the log file output.
                     results.problem.number_of_variables = int(tokens[2])
+                if "Nneg" in tokens[3]:
+                    results.problem.number_of_continuous_variables = int(tokens[4][:-1])  # remove trailing comma
+                if "Binary" in tokens[5]:
+                    results.problem.number_of_binary_variables = int(tokens[6][:-1])  # remove trailing bracket
             # In CPLEX 11 (and presumably before), there was only a single line output to
             # indicate the constriant count, e.g., "Linear constraints : 16 [Less: 7, Greater: 6, Equal: 3]".
             # In CPLEX 11.2 (or somewhere in between 11 and 11.2 - I haven't bothered to track it down

--- a/pyomo/solvers/plugins/solvers/CPLEX.py
+++ b/pyomo/solvers/plugins/solvers/CPLEX.py
@@ -619,7 +619,7 @@ class CPLEXSHELL(ILMLicensedSystemCallSolver):
                 results.solver.termination_condition = TerminationCondition.noSolution
                 results.solver.termination_message = ' '.join(tokens)
             elif len(tokens) >= 9 and tokens[0] == "MIP" and tokens[1] == "start" and tokens[7] == "objective":
-                results.solver.warm_start_objective_value = float(tokens[8][:-1])  # remove trailing full stop
+                results.solver.warm_start_objective_value = float(tokens[8].rstrip('.'))
             elif len(tokens) >= 5 and tokens[0:2] == ["Solution", "pool:"] and tokens[3] in ["solution", "solutions"] and tokens[4] == "saved.":
                 results.solver.n_solutions_found = int(tokens[2])
             elif len(tokens) >= 10 and tokens[0] == "Current" and tokens[1] == "MIP" and tokens[2] == "best" and tokens[3] == "bound":

--- a/pyomo/solvers/plugins/solvers/CPLEX.py
+++ b/pyomo/solvers/plugins/solvers/CPLEX.py
@@ -516,10 +516,10 @@ class CPLEXSHELL(ILMLicensedSystemCallSolver):
             results.solver.root_node_processing_time = float(root_node_processing_time.group(1))
 
         tree_processing_time = re.search(
-            r'(Parallel|Sequential).*\n\s+Real time\s+=\s+(\d+\.\d+) sec', output
+            r'(?:Parallel|Sequential).*\n\s+Real time\s+=\s+(\d+\.\d+) sec', output
         )
         if tree_processing_time:
-            results.solver.tree_processing_time = float(tree_processing_time.group(2))
+            results.solver.tree_processing_time = float(tree_processing_time.group(1))
 
         for line in output.split("\n"):
             tokens = re.split('[ \t]+',line.strip())

--- a/pyomo/solvers/plugins/solvers/CPLEX.py
+++ b/pyomo/solvers/plugins/solvers/CPLEX.py
@@ -616,6 +616,8 @@ class CPLEXSHELL(ILMLicensedSystemCallSolver):
                 results.solver.termination_message = ' '.join(tokens)
             elif len(tokens) >= 9 and tokens[0] == "MIP" and tokens[1] == "start" and tokens[7] == "objective":
                 results.solver.warm_start_objective_value = float(tokens[8][:-1])  # remove trailing full stop
+            elif len(tokens) >= 5 and tokens[0] == "Solution" and tokens[1] == "pool:" and tokens[3] in ["solution", "solutions"] and tokens[4] == "saved.":
+                results.solver.n_solutions_found = int(tokens[2])
             elif len(tokens) >= 10 and tokens[0] == "Current" and tokens[1] == "MIP" and tokens[2] == "best" and tokens[3] == "bound":
                 self._best_bound = float(tokens[5])
                 self._gap = float(tokens[8].rstrip(','))

--- a/pyomo/solvers/tests/checks/test_cplex.py
+++ b/pyomo/solvers/tests/checks/test_cplex.py
@@ -382,6 +382,25 @@ MIP start 'm1' defined initial solution with objective 25210.5363.
         results = CPLEXSHELL.process_logfile(self.solver)
         self.assertEqual(results.solver.warm_start_objective_value, 25210.5363)
 
+    def test_log_file_shows_root_node_processing(self):
+        log_file_text = """
+Presolve time = 0.14 sec. (181.11 ticks)
+
+Root node processing (before b&c):
+  Real time             =    123.45 sec. (211.39 ticks)
+Parallel b&c, 16 threads:
+  Real time             =    0.00 sec. (0.00 ticks)
+  Sync time (average)   =    0.00 sec.
+  Wait time (average)   =    0.00 sec.
+                          ------------
+Total (root+branch&cut) =    0.18 sec. (211.39 ticks)
+ """
+        with open(self.solver._log_file, "w") as f:
+            f.write(log_file_text)
+
+        results = CPLEXSHELL.process_logfile(self.solver)
+        self.assertEqual(results.solver.root_node_processing_time, 123.45)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/pyomo/solvers/tests/checks/test_cplex.py
+++ b/pyomo/solvers/tests/checks/test_cplex.py
@@ -382,24 +382,43 @@ MIP start 'm1' defined initial solution with objective 25210.5363.
         results = CPLEXSHELL.process_logfile(self.solver)
         self.assertEqual(results.solver.warm_start_objective_value, 25210.5363)
 
-    def test_log_file_shows_root_node_processing(self):
+    def test_log_file_shows_root_node_processing_time(self):
         log_file_text = """
 Presolve time = 0.14 sec. (181.11 ticks)
 
 Root node processing (before b&c):
   Real time             =    123.45 sec. (211.39 ticks)
 Parallel b&c, 16 threads:
-  Real time             =    0.00 sec. (0.00 ticks)
+  Real time             =    67.89 sec. (56.98 ticks)
   Sync time (average)   =    0.00 sec.
   Wait time (average)   =    0.00 sec.
                           ------------
-Total (root+branch&cut) =    0.18 sec. (211.39 ticks)
+Total (root+branch&cut) =    191.34 sec. (268.37 ticks)
  """
         with open(self.solver._log_file, "w") as f:
             f.write(log_file_text)
 
         results = CPLEXSHELL.process_logfile(self.solver)
         self.assertEqual(results.solver.root_node_processing_time, 123.45)
+
+    def test_log_file_shows_tree_processing_time(self):
+        log_file_text = """
+Presolve time = 0.14 sec. (181.11 ticks)
+
+Root node processing (before b&c):
+  Real time             =    123.45 sec. (211.39 ticks)
+Parallel b&c, 16 threads:
+  Real time             =    67.89 sec. (56.98 ticks)
+  Sync time (average)   =    0.00 sec.
+  Wait time (average)   =    0.00 sec.
+                          ------------
+Total (root+branch&cut) =    191.34 sec. (268.37 ticks)
+ """
+        with open(self.solver._log_file, "w") as f:
+            f.write(log_file_text)
+
+        results = CPLEXSHELL.process_logfile(self.solver)
+        self.assertEqual(results.solver.tree_processing_time, 67.89)
 
 
 if __name__ == "__main__":

--- a/pyomo/solvers/tests/checks/test_cplex.py
+++ b/pyomo/solvers/tests/checks/test_cplex.py
@@ -401,13 +401,32 @@ Total (root+branch&cut) =    191.34 sec. (268.37 ticks)
         results = CPLEXSHELL.process_logfile(self.solver)
         self.assertEqual(results.solver.root_node_processing_time, 123.45)
 
-    def test_log_file_shows_tree_processing_time(self):
+    def test_log_file_shows_tree_processing_time_when_parallel(self):
         log_file_text = """
 Presolve time = 0.14 sec. (181.11 ticks)
 
 Root node processing (before b&c):
   Real time             =    123.45 sec. (211.39 ticks)
 Parallel b&c, 16 threads:
+  Real time             =    67.89 sec. (56.98 ticks)
+  Sync time (average)   =    0.00 sec.
+  Wait time (average)   =    0.00 sec.
+                          ------------
+Total (root+branch&cut) =    191.34 sec. (268.37 ticks)
+ """
+        with open(self.solver._log_file, "w") as f:
+            f.write(log_file_text)
+
+        results = CPLEXSHELL.process_logfile(self.solver)
+        self.assertEqual(results.solver.tree_processing_time, 67.89)
+
+    def test_log_file_shows_tree_processing_time_when_sequential(self):
+        log_file_text = """
+Presolve time = 0.14 sec. (181.11 ticks)
+
+Root node processing (before b&c):
+  Real time             =    123.45 sec. (211.39 ticks)
+Sequential b&c:
   Real time             =    67.89 sec. (56.98 ticks)
   Sync time (average)   =    0.00 sec.
   Wait time (average)   =    0.00 sec.

--- a/pyomo/solvers/tests/checks/test_cplex.py
+++ b/pyomo/solvers/tests/checks/test_cplex.py
@@ -420,6 +420,26 @@ Total (root+branch&cut) =    191.34 sec. (268.37 ticks)
         results = CPLEXSHELL.process_logfile(self.solver)
         self.assertEqual(results.solver.tree_processing_time, 67.89)
 
+    def test_log_file_shows_n_solutions_found_when_multiple(self):
+        log_file_text = """
+Solution pool: 15 solutions saved.
+ """
+        with open(self.solver._log_file, "w") as f:
+            f.write(log_file_text)
+
+        results = CPLEXSHELL.process_logfile(self.solver)
+        self.assertEqual(results.solver.n_solutions_found, 15)
+
+    def test_log_file_shows_n_solutions_found_when_single(self):
+        log_file_text = """
+Solution pool: 1 solution saved.
+ """
+        with open(self.solver._log_file, "w") as f:
+            f.write(log_file_text)
+
+        results = CPLEXSHELL.process_logfile(self.solver)
+        self.assertEqual(results.solver.n_solutions_found, 1)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/pyomo/solvers/tests/checks/test_cplex.py
+++ b/pyomo/solvers/tests/checks/test_cplex.py
@@ -13,43 +13,19 @@ import os
 import pyutilib
 import pyutilib.th as unittest
 
-from pyomo.core import (
-    Binary,
-    ConcreteModel,
-    Constraint,
-    Objective,
-    Var,
-    Integers,
-    RangeSet,
-    minimize,
-    quicksum,
-    Suffix,
-)
-from pyomo.opt import (
-    BranchDirection,
-    ProblemFormat,
-    SolverFactory,
-    SolverStatus,
-    TerminationCondition,
-    convert_problem,
-)
-from pyomo.solvers.plugins.solvers.CPLEX import (
-    CPLEXSHELL,
-    MockCPLEX,
-    _validate_file_name,
-    ORDFileSchema,
-)
+from pyomo.core import Binary, ConcreteModel, Constraint, Objective, Var, Integers, RangeSet, minimize, quicksum, Suffix
+from pyomo.opt import (BranchDirection, ProblemFormat, SolverFactory,
+                       SolverStatus, TerminationCondition, convert_problem)
+from pyomo.solvers.plugins.solvers.CPLEX import CPLEXSHELL, MockCPLEX, _validate_file_name, ORDFileSchema
 
 
 class _mock_cplex_128(object):
     def version(self):
-        return (12, 8, 0)
-
+        return (12,8,0)
 
 class _mock_cplex_126(object):
     def version(self):
-        return (12, 6, 0)
-
+        return (12,6,0)
 
 class CPLEX_utils(unittest.TestCase):
     def test_validate_file_name(self):
@@ -57,41 +33,38 @@ class CPLEX_utils(unittest.TestCase):
         _128 = _mock_cplex_128()
 
         # Check plain file
-        fname = "foo.lp"
-        self.assertEqual(fname, _validate_file_name(_126, fname, "xxx"))
-        self.assertEqual(fname, _validate_file_name(_128, fname, "xxx"))
+        fname = 'foo.lp'
+        self.assertEqual(fname, _validate_file_name(_126, fname, 'xxx'))
+        self.assertEqual(fname, _validate_file_name(_128, fname, 'xxx'))
 
         # Check spaces in the file
-        fname = "foo bar.lp"
-        with self.assertRaisesRegexp(ValueError, "Space detected in CPLEX xxx file"):
-            _validate_file_name(_126, fname, "xxx")
-        self.assertEqual('"%s"' % (fname,), _validate_file_name(_128, fname, "xxx"))
+        fname = 'foo bar.lp'
+        with self.assertRaisesRegexp(
+                ValueError, "Space detected in CPLEX xxx file"):
+            _validate_file_name(_126, fname, 'xxx')
+        self.assertEqual('"%s"' % (fname,),
+                         _validate_file_name(_128, fname, 'xxx'))
 
         # check OK path separators
-        fname = "foo%sbar.lp" % (os.path.sep,)
-        self.assertEqual(fname, _validate_file_name(_126, fname, "xxx"))
-        self.assertEqual(fname, _validate_file_name(_128, fname, "xxx"))
+        fname = 'foo%sbar.lp' % (os.path.sep,)
+        self.assertEqual(fname, _validate_file_name(_126, fname, 'xxx'))
+        self.assertEqual(fname, _validate_file_name(_128, fname, 'xxx'))
 
         # check BAD path separators
-        bad_char = "/\\".replace(os.path.sep, "")
-        fname = "foo%sbar.lp" % (bad_char,)
-        msg = "Unallowed character \(%s\) found in CPLEX xxx file" % (
-            repr(bad_char)[1:-1],
-        )
+        bad_char = '/\\'.replace(os.path.sep,'')
+        fname = 'foo%sbar.lp' % (bad_char,)
+        msg = 'Unallowed character \(%s\) found in CPLEX xxx file' % (
+            repr(bad_char)[1:-1],)
         with self.assertRaisesRegexp(ValueError, msg):
-            _validate_file_name(_126, fname, "xxx")
+            _validate_file_name(_126, fname, 'xxx')
         with self.assertRaisesRegexp(ValueError, msg):
-            _validate_file_name(_128, fname, "xxx")
+            _validate_file_name(_128, fname, 'xxx')
 
 
 class CPLEXShellWritePrioritiesFile(unittest.TestCase):
     def setUp(self):
-        from pyomo.solvers.plugins.converter.model import (
-            PyomoMIPConverter,
-        )  # register the `ProblemConverterFactory`
-        from pyomo.repn.plugins.cpxlp import (
-            ProblemWriter_cpxlp,
-        )  # register the `WriterFactory`
+        from pyomo.solvers.plugins.converter.model import PyomoMIPConverter  # register the `ProblemConverterFactory`
+        from pyomo.repn.plugins.cpxlp import ProblemWriter_cpxlp  # register the `WriterFactory`
 
         self.mock_model = self.get_mock_model()
         self.mock_cplex_shell = self.get_mock_cplex_shell(self.mock_model)
@@ -355,7 +328,9 @@ CPLEX>"""
         self.assertEqual(
             results.solver.termination_condition, TerminationCondition.infeasible
         )
-        self.assertEqual(results.solver.termination_message, "Presolve - Infeasible.")
+        self.assertEqual(
+            results.solver.termination_message, "Presolve - Infeasible."
+        )
         self.assertEqual(results.solver.return_code, 1217)
 
     def test_log_file_shows_max_time_limit_exceeded_with_feasible_solution(self):
@@ -377,9 +352,7 @@ CPLEX>"""
         )
         self.assertEqual(results.solver.deterministic_time, 100.00)
 
-    def test_log_file_shows_max_deterministic_time_limit_exceeded_with_feasible_solution(
-        self
-    ):
+    def test_log_file_shows_max_deterministic_time_limit_exceeded_with_feasible_solution(self):
         log_file_text = """
 MIP - Deterministic time limit exceeded, integer feasible:  Objective =  0.0000000000e+00
 Current MIP best bound =  0.0000000000e+00 (gap = 10.0, 10.00%)

--- a/pyomo/solvers/tests/checks/test_cplex.py
+++ b/pyomo/solvers/tests/checks/test_cplex.py
@@ -440,6 +440,30 @@ Solution pool: 1 solution saved.
         results = CPLEXSHELL.process_logfile(self.solver)
         self.assertEqual(results.solver.n_solutions_found, 1)
 
+    def test_log_file_shows_number_of_binary_variables(self):
+        log_file_text = """
+Objective sense      : Minimize
+Variables            :     506  [Nneg: 206,  Binary: 300]
+Objective nonzeros   :      32
+ """
+        with open(self.solver._log_file, "w") as f:
+            f.write(log_file_text)
+
+        results = CPLEXSHELL.process_logfile(self.solver)
+        self.assertEqual(results.problem.number_of_binary_variables, 300)
+
+    def test_log_file_shows_number_of_continuous_variables(self):
+        log_file_text = """
+Objective sense      : Minimize
+Variables            :     506  [Nneg: 206,  Binary: 300]
+Objective nonzeros   :      32
+ """
+        with open(self.solver._log_file, "w") as f:
+            f.write(log_file_text)
+
+        results = CPLEXSHELL.process_logfile(self.solver)
+        self.assertEqual(results.problem.number_of_continuous_variables, 206)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/pyomo/solvers/tests/checks/test_cplex.py
+++ b/pyomo/solvers/tests/checks/test_cplex.py
@@ -13,19 +13,43 @@ import os
 import pyutilib
 import pyutilib.th as unittest
 
-from pyomo.core import Binary, ConcreteModel, Constraint, Objective, Var, Integers, RangeSet, minimize, quicksum, Suffix
-from pyomo.opt import (BranchDirection, ProblemFormat, SolverFactory,
-                       SolverStatus, TerminationCondition, convert_problem)
-from pyomo.solvers.plugins.solvers.CPLEX import CPLEXSHELL, MockCPLEX, _validate_file_name, ORDFileSchema
+from pyomo.core import (
+    Binary,
+    ConcreteModel,
+    Constraint,
+    Objective,
+    Var,
+    Integers,
+    RangeSet,
+    minimize,
+    quicksum,
+    Suffix,
+)
+from pyomo.opt import (
+    BranchDirection,
+    ProblemFormat,
+    SolverFactory,
+    SolverStatus,
+    TerminationCondition,
+    convert_problem,
+)
+from pyomo.solvers.plugins.solvers.CPLEX import (
+    CPLEXSHELL,
+    MockCPLEX,
+    _validate_file_name,
+    ORDFileSchema,
+)
 
 
 class _mock_cplex_128(object):
     def version(self):
-        return (12,8,0)
+        return (12, 8, 0)
+
 
 class _mock_cplex_126(object):
     def version(self):
-        return (12,6,0)
+        return (12, 6, 0)
+
 
 class CPLEX_utils(unittest.TestCase):
     def test_validate_file_name(self):
@@ -33,38 +57,41 @@ class CPLEX_utils(unittest.TestCase):
         _128 = _mock_cplex_128()
 
         # Check plain file
-        fname = 'foo.lp'
-        self.assertEqual(fname, _validate_file_name(_126, fname, 'xxx'))
-        self.assertEqual(fname, _validate_file_name(_128, fname, 'xxx'))
+        fname = "foo.lp"
+        self.assertEqual(fname, _validate_file_name(_126, fname, "xxx"))
+        self.assertEqual(fname, _validate_file_name(_128, fname, "xxx"))
 
         # Check spaces in the file
-        fname = 'foo bar.lp'
-        with self.assertRaisesRegexp(
-                ValueError, "Space detected in CPLEX xxx file"):
-            _validate_file_name(_126, fname, 'xxx')
-        self.assertEqual('"%s"' % (fname,),
-                         _validate_file_name(_128, fname, 'xxx'))
+        fname = "foo bar.lp"
+        with self.assertRaisesRegexp(ValueError, "Space detected in CPLEX xxx file"):
+            _validate_file_name(_126, fname, "xxx")
+        self.assertEqual('"%s"' % (fname,), _validate_file_name(_128, fname, "xxx"))
 
         # check OK path separators
-        fname = 'foo%sbar.lp' % (os.path.sep,)
-        self.assertEqual(fname, _validate_file_name(_126, fname, 'xxx'))
-        self.assertEqual(fname, _validate_file_name(_128, fname, 'xxx'))
+        fname = "foo%sbar.lp" % (os.path.sep,)
+        self.assertEqual(fname, _validate_file_name(_126, fname, "xxx"))
+        self.assertEqual(fname, _validate_file_name(_128, fname, "xxx"))
 
         # check BAD path separators
-        bad_char = '/\\'.replace(os.path.sep,'')
-        fname = 'foo%sbar.lp' % (bad_char,)
-        msg = 'Unallowed character \(%s\) found in CPLEX xxx file' % (
-            repr(bad_char)[1:-1],)
+        bad_char = "/\\".replace(os.path.sep, "")
+        fname = "foo%sbar.lp" % (bad_char,)
+        msg = "Unallowed character \(%s\) found in CPLEX xxx file" % (
+            repr(bad_char)[1:-1],
+        )
         with self.assertRaisesRegexp(ValueError, msg):
-            _validate_file_name(_126, fname, 'xxx')
+            _validate_file_name(_126, fname, "xxx")
         with self.assertRaisesRegexp(ValueError, msg):
-            _validate_file_name(_128, fname, 'xxx')
+            _validate_file_name(_128, fname, "xxx")
 
 
 class CPLEXShellWritePrioritiesFile(unittest.TestCase):
     def setUp(self):
-        from pyomo.solvers.plugins.converter.model import PyomoMIPConverter  # register the `ProblemConverterFactory`
-        from pyomo.repn.plugins.cpxlp import ProblemWriter_cpxlp  # register the `WriterFactory`
+        from pyomo.solvers.plugins.converter.model import (
+            PyomoMIPConverter,
+        )  # register the `ProblemConverterFactory`
+        from pyomo.repn.plugins.cpxlp import (
+            ProblemWriter_cpxlp,
+        )  # register the `WriterFactory`
 
         self.mock_model = self.get_mock_model()
         self.mock_cplex_shell = self.get_mock_cplex_shell(self.mock_model)
@@ -328,9 +355,7 @@ CPLEX>"""
         self.assertEqual(
             results.solver.termination_condition, TerminationCondition.infeasible
         )
-        self.assertEqual(
-            results.solver.termination_message, "Presolve - Infeasible."
-        )
+        self.assertEqual(results.solver.termination_message, "Presolve - Infeasible.")
         self.assertEqual(results.solver.return_code, 1217)
 
     def test_log_file_shows_max_time_limit_exceeded_with_feasible_solution(self):
@@ -352,7 +377,9 @@ CPLEX>"""
         )
         self.assertEqual(results.solver.deterministic_time, 100.00)
 
-    def test_log_file_shows_max_deterministic_time_limit_exceeded_with_feasible_solution(self):
+    def test_log_file_shows_max_deterministic_time_limit_exceeded_with_feasible_solution(
+        self
+    ):
         log_file_text = """
 MIP - Deterministic time limit exceeded, integer feasible:  Objective =  0.0000000000e+00
 Current MIP best bound =  0.0000000000e+00 (gap = 10.0, 10.00%)
@@ -470,6 +497,18 @@ Objective nonzeros   :      32
 
         results = CPLEXSHELL.process_logfile(self.solver)
         self.assertEqual(results.problem.number_of_binary_variables, 300)
+
+    def test_log_file_shows_number_of_binary_variables_when_integer_variables_are_present(
+        self
+    ):
+        log_file_text = """
+Variables : 7 [Nneg: 1, Binary: 4, General Integer: 2]
+ """
+        with open(self.solver._log_file, "w") as f:
+            f.write(log_file_text)
+
+        results = CPLEXSHELL.process_logfile(self.solver)
+        self.assertEqual(results.problem.number_of_binary_variables, 4)
 
     def test_log_file_shows_number_of_continuous_variables(self):
         log_file_text = """

--- a/pyomo/solvers/tests/checks/test_cplex.py
+++ b/pyomo/solvers/tests/checks/test_cplex.py
@@ -371,5 +371,17 @@ CPLEX>"""
         )
         self.assertEqual(results.solver.deterministic_time, 100.00)
 
+    def test_log_file_shows_warm_start_objective_value(self):
+        log_file_text = """
+1 of 1 MIP starts provided solutions.
+MIP start 'm1' defined initial solution with objective 25210.5363.
+"""
+        with open(self.solver._log_file, "w") as f:
+            f.write(log_file_text)
+
+        results = CPLEXSHELL.process_logfile(self.solver)
+        self.assertEqual(results.solver.warm_start_objective_value, 25210.5363)
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary/Motivation:
Parse more useful info from the CPLEX log and save them to `results.problem` and `results.sovler.`

Note that for some we need to use regular expressions before breaking `output` in individual lines due to the message being identifiable solely by text on the preceding line.

## Changes proposed in this PR:
- Parse more info from CPLEX logs

### Legal Acknowledgement

By contributing to this software project, I agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
