### PR TITLE
:bug: Consider "det time limit" as `user_limit_exceeded`

### DIFF
--- a/pyomo/solvers/plugins/solvers/CPLEX.py
+++ b/pyomo/solvers/plugins/solvers/CPLEX.py
@@ -860,7 +860,11 @@ class CPLEXSHELL(ILMLicensedSystemCallSolver):
                 elif solution_status in ["infeasible"]:
                     soln.status = SolutionStatus.infeasible
                     soln.gap = None
-                elif solution_status in ["time limit exceeded", "solution limit exceeded"]:
+                elif solution_status in {
+                    "time limit exceeded",
+                    "solution limit exceeded",
+                    "deterministic time limit exceeded"
+                }:
                     # we need to know if the solution is primal feasible, and if it is, set the solution status accordingly.
                     # for now, just set the flag so we can trigger the logic when we see the primalFeasible keyword.
                     user_defined_limit_exceeded = True


### PR DESCRIPTION
:bug: Consider "det time limit" as `user_limit_exceeded`

- When using the deterministic time limit interface of CPLEX, we expect the solution parsing behaviour to mimic that of using the seconds-interface
- Notably, this is causing the parsing of `problem.upper_bound` and `problem.lower_bound` to be incorrect otherwise
- These are handled correctly when `user_defined_limit_exceeded = True` therefore we need this to be `True` for the det timelimit too 

## Changes proposed in this PR:
- Parse a solution from the deterministic time limit interface in the same manner as the non-deterministic time limit interface
