### PR TITLE
Mip start failures

### DIFF
--- a/pyomo/opt/results/solver.py
+++ b/pyomo/opt/results/solver.py
@@ -219,3 +219,5 @@ class SolverInformation(MapContainer):
         self.declare('tree_processing_time', type=ScalarType.time)
         # Semantics: The number of feasible solutions found.
         self.declare('n_solutions_found', type=ScalarType.int)
+        # Semantics: If mip start was attempted but failed to provide a feasible solution.
+        self.declare('mip_start_failed', type=bool)

--- a/pyomo/solvers/plugins/solvers/CPLEX.py
+++ b/pyomo/solvers/plugins/solvers/CPLEX.py
@@ -528,7 +528,8 @@ class CPLEXSHELL(ILMLicensedSystemCallSolver):
             results.solver.tree_processing_time = float(tree_processing_time.group(1))
 
         # Check if a mip start was attempted but failed
-        results.solver.mip_start_failed = did_mip_start_fail_from_logs(output)
+        mip_start_warning = re.search(r'Warning:\s+No solution found from \d+ MIP starts', output)
+        results.solver.mip_start_failed = bool(mip_start_warning)
 
         for line in output.split("\n"):
             tokens = re.split('[ \t]+',line.strip())
@@ -1008,9 +1009,3 @@ class MockCPLEX(CPLEXSHELL,MockMIP):
 
     def _execute_command(self, cmd):
         return MockMIP._execute_command(self, cmd)
-
-
-def did_mip_start_fail_from_logs(log_output) -> bool:
-    mip_start_warning = re.search(r'Warning:\s+No solution found from \d+ MIP starts', log_output)
-    return bool(mip_start_warning)
-

--- a/pyomo/solvers/plugins/solvers/CPLEX.py
+++ b/pyomo/solvers/plugins/solvers/CPLEX.py
@@ -528,8 +528,7 @@ class CPLEXSHELL(ILMLicensedSystemCallSolver):
             results.solver.tree_processing_time = float(tree_processing_time.group(1))
 
         # Check if a mip start was attempted but failed
-        mip_start_warning = re.search(r'Warning:\s+No solution found from \d+ MIP starts', output)
-        results.solver.mip_start_failed = bool(mip_start_warning)
+        results.solver.mip_start_failed = did_mip_start_fail_from_logs(output)
 
         for line in output.split("\n"):
             tokens = re.split('[ \t]+',line.strip())
@@ -1010,4 +1009,8 @@ class MockCPLEX(CPLEXSHELL,MockMIP):
     def _execute_command(self, cmd):
         return MockMIP._execute_command(self, cmd)
 
+
+def did_mip_start_fail_from_logs(log_output) -> bool:
+    mip_start_warning = re.search(r'Warning:\s+No solution found from \d+ MIP starts', log_output)
+    return bool(mip_start_warning)
 

--- a/pyomo/solvers/plugins/solvers/CPLEX.py
+++ b/pyomo/solvers/plugins/solvers/CPLEX.py
@@ -527,6 +527,10 @@ class CPLEXSHELL(ILMLicensedSystemCallSolver):
         if tree_processing_time:
             results.solver.tree_processing_time = float(tree_processing_time.group(1))
 
+        # Check if a mip start was attempted but failed
+        mip_start_warning = re.search(r'Warning:\s+No solution found from \d+ MIP starts', output)
+        results.solver.mip_start_failed = bool(mip_start_warning)
+
         for line in output.split("\n"):
             tokens = re.split('[ \t]+',line.strip())
             if len(tokens) > 3 and ("CPLEX", "Error") in {tuple(tokens[0:2]), tuple(tokens[1:3])}:

--- a/pyomo/solvers/plugins/solvers/cplex_direct.py
+++ b/pyomo/solvers/plugins/solvers/cplex_direct.py
@@ -26,7 +26,6 @@ from pyomo.opt.results.results_ import SolverResults
 from pyomo.opt.results.solution import Solution, SolutionStatus
 from pyomo.opt.results.solver import TerminationCondition, SolverStatus
 from pyomo.opt.base import SolverFactory
-from pyomo.solvers.plugins.solvers.CPLEX import did_mip_start_fail_from_logs
 import time
 
 
@@ -861,19 +860,6 @@ class CPLEXDirect(DirectSolver):
                     self._load_slacks()
 
         self.results.solution.insert(soln)
-
-        # Get additional solver output from log file
-        if self.version() >= (12, 5, 1) \
-           and isinstance(self._log_file, six.string_types):
-            _log_file = open(self._log_file, 'r')
-            _close_log_file = True
-        else:
-            _log_file = self._log_file
-            _close_log_file = False
-        log_output = "".join(_log_file.readlines())
-        if _close_log_file:
-            _log_file.close()
-        self.results.solver.mip_start_failed = did_mip_start_fail_from_logs(log_output)
 
         # finally, clean any temporary files registered with the temp file
         # manager, created populated *directly* by this plugin.

--- a/pyomo/solvers/plugins/solvers/cplex_direct.py
+++ b/pyomo/solvers/plugins/solvers/cplex_direct.py
@@ -862,17 +862,18 @@ class CPLEXDirect(DirectSolver):
 
         self.results.solution.insert(soln)
 
-        # Get additional solver information from log file
+        # Get additional solver output from log file
         if self.version() >= (12, 5, 1) \
            and isinstance(self._log_file, six.string_types):
-            _log_file = (open(self._log_file, 'a'),)
+            _log_file = open(self._log_file, 'r')
             _close_log_file = True
         else:
-            _log_file = (self._log_file,)
+            _log_file = self._log_file
             _close_log_file = False
-        self.results.solver.mip_start_failed = did_mip_start_fail_from_logs(_log_file)
+        log_output = "".join(_log_file.readlines())
         if _close_log_file:
-            _log_file[0].close()
+            _log_file.close()
+        self.results.solver.mip_start_failed = did_mip_start_fail_from_logs(log_output)
 
         # finally, clean any temporary files registered with the temp file
         # manager, created populated *directly* by this plugin.

--- a/pyomo/solvers/plugins/solvers/cplex_direct.py
+++ b/pyomo/solvers/plugins/solvers/cplex_direct.py
@@ -26,6 +26,7 @@ from pyomo.opt.results.results_ import SolverResults
 from pyomo.opt.results.solution import Solution, SolutionStatus
 from pyomo.opt.results.solver import TerminationCondition, SolverStatus
 from pyomo.opt.base import SolverFactory
+from pyomo.solvers.plugins.solvers.CPLEX import did_mip_start_fail_from_logs
 import time
 
 
@@ -860,6 +861,18 @@ class CPLEXDirect(DirectSolver):
                     self._load_slacks()
 
         self.results.solution.insert(soln)
+
+        # Get additional solver information from log file
+        if self.version() >= (12, 5, 1) \
+           and isinstance(self._log_file, six.string_types):
+            _log_file = (open(self._log_file, 'a'),)
+            _close_log_file = True
+        else:
+            _log_file = (self._log_file,)
+            _close_log_file = False
+        self.results.solver.mip_start_failed = did_mip_start_fail_from_logs(_log_file)
+        if _close_log_file:
+            _log_file[0].close()
 
         # finally, clean any temporary files registered with the temp file
         # manager, created populated *directly* by this plugin.

--- a/pyomo/solvers/tests/checks/test_cplex.py
+++ b/pyomo/solvers/tests/checks/test_cplex.py
@@ -430,6 +430,16 @@ MIP start 'm1' defined initial solution with objective 25210.5363.
         results = CPLEXSHELL.process_logfile(self.solver)
         self.assertEqual(results.solver.warm_start_objective_value, 25210.5363)
 
+    def test_log_file_shows_warm_start_failure(self):
+        log_file_text = """
+Warning:  No solution found from 1 MIP starts.
+"""
+        with open(self.solver._log_file, "w") as f:
+            f.write(log_file_text)
+
+        results = CPLEXSHELL.process_logfile(self.solver)
+        self.assertEqual(results.solver.mip_start_failed, True)
+
     def test_log_file_shows_root_node_processing_time(self):
         log_file_text = """
 Presolve time = 0.14 sec. (181.11 ticks)


### PR DESCRIPTION
## Fixes # .

## Summary/Motivation:
Adds an attribute to pyomo results to show if mip start failed

## Changes proposed in this PR:
- Add `mip_start_failed` to solver results by searching logs
-

### Legal Acknowledgement

By contributing to this software project, I have read the [contribution guide](https://pyomo.readthedocs.io/en/stable/contribution_guide.html) and agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
