### PR TITLE
feat: introducing CPLEX_VERSION environment variable

### DIFF
--- a/pyomo/solvers/plugins/solvers/CPLEX.py
+++ b/pyomo/solvers/plugins/solvers/CPLEX.py
@@ -388,13 +388,20 @@ class CPLEXSHELL(ILMLicensedSystemCallSolver):
         """
         Returns a tuple describing the solver executable version.
         """
+        # The subprocess below can sometimes time out if we're low on resources. This gives us a much
+        # cheaper way of getting the version
+        version_from_env = _extract_version(os.environ.get('CPLEX_VERSION', ''))
+        if version_from_env:
+            return version_from_env
+
         solver_exec = self.executable()
         if solver_exec is None:
             return _extract_version('')
-        results = subprocess.run( [solver_exec,'-c','quit'], timeout=1,
-                                 stdout=subprocess.PIPE,
-                                 stderr=subprocess.STDOUT,
-                                 universal_newlines=True)
+        results = subprocess.run( [solver_exec,'-c','quit'],
+                                  timeout=1,
+                                  stdout=subprocess.PIPE,
+                                  stderr=subprocess.STDOUT,
+                                  universal_newlines=True)
         return _extract_version(results.stdout)
 
     def create_command_line(self, executable, problem_files):

--- a/pyomo/solvers/tests/checks/test_cplex.py
+++ b/pyomo/solvers/tests/checks/test_cplex.py
@@ -9,6 +9,11 @@
 #  ___________________________________________________________________________
 
 import os
+from contextlib import contextmanager
+from unittest.mock import Mock
+from parameterized import parameterized
+
+from pyomo.opt.base.solvers import _extract_version
 
 from pyomo.common.tempfiles import TempfileManager
 import pyomo.common.unittest as unittest
@@ -590,6 +595,47 @@ Objective nonzeros   :      32
 
         results = CPLEXSHELL.process_logfile(self.solver)
         self.assertEqual(results.problem.number_of_continuous_variables, 206)
+
+
+class TestCplexVersion:
+    ENV_VAR_NAME = 'CPLEX_VERSION'
+
+    @contextmanager
+    def temp_cplex_env_var_value(self, value):
+        old_environ = dict(os.environ)
+        if value is None:
+            os.environ.pop(self.ENV_VAR_NAME, None)
+        else:
+            os.environ[self.ENV_VAR_NAME] = value
+        try:
+            yield
+        finally:
+            os.environ.clear()
+            os.environ.update(old_environ)
+
+    def test_it_uses_env_var(self):
+        with self.temp_cplex_env_var_value('20.1.0'):
+            cplex = MockCPLEX()
+            assert cplex.version() == (20, 1, 0, 0)
+
+    @parameterized.expand([
+        [None],
+        ["invalid_version"],
+    ])
+    def test_it_uses_subprocess_when_env_var_invalid(self, invalid_env_value):
+        with self.temp_cplex_env_var_value(invalid_env_value), unittest.mock.patch(
+            "pyomo.solvers.plugins.solvers.CPLEX.subprocess"
+        ) as mock_subprocess:
+            mock_subprocess.run.return_value = Mock(stdout='20.0.0')
+            cplex = MockCPLEX()
+            assert cplex.version() == (20, 0, 0, 0)
+            mock_subprocess.run.assert_called_once_with(
+                [cplex.executable(), '-c', 'quit'],
+                timeout=1,
+                stdout=mock_subprocess.PIPE,
+                stderr=mock_subprocess.STDOUT,
+                universal_newlines=True
+            )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
This allows us to skip running the subprocess to find the cplex version
in situations where this version is constant and known.

## Fixes # .

## Summary/Motivation:


## Changes proposed in this PR:
-
-

### Legal Acknowledgement

By contributing to this software project, I have read the [contribution guide](https://pyomo.readthedocs.io/en/stable/contribution_guide.html) and agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
