### PR TITLE
Populate solver (warm start objective value, processing times) when using `CPLEXDirect`

### DIFF
--- a/pyomo/solvers/plugins/solvers/CPLEX.py
+++ b/pyomo/solvers/plugins/solvers/CPLEX.py
@@ -33,6 +33,7 @@ from pyomo.solvers.mockmip import MockMIP
 from pyomo.core.base import Var, Suffix, active_export_suffix_generator
 from pyomo.core.kernel.suffix import export_suffix_generator
 from pyomo.core.kernel.block import IBlock
+from pyomo.solvers.plugins.solvers.cplex_helpers import get_tree_processing_time, get_root_node_processing_time
 from pyomo.util.components import iter_component
 
 logger = logging.getLogger('pyomo.solvers')
@@ -519,17 +520,12 @@ class CPLEXSHELL(ILMLicensedSystemCallSolver):
         self._gap = None
 
         # use regular expressions to use multi-line match patterns:
-        root_node_processing_time = re.search(
-            r'Root node processing.*:\n\s+Real time\s+=\s+(\d+\.\d+) sec', output
+        self.results.solver.root_node_processing_time = get_root_node_processing_time(
+            log_output=output
         )
-        if root_node_processing_time:
-            results.solver.root_node_processing_time = float(root_node_processing_time.group(1))
-
-        tree_processing_time = re.search(
-            r'(?:Parallel|Sequential).*\n\s+Real time\s+=\s+(\d+\.\d+) sec', output
+        self.results.solver.tree_processing_time = get_tree_processing_time(
+            log_output=output
         )
-        if tree_processing_time:
-            results.solver.tree_processing_time = float(tree_processing_time.group(1))
 
         # Check if a mip start was attempted but failed
         mip_start_warning = re.search(r'Warning:\s+No solution found from \d+ MIP starts', output)

--- a/pyomo/solvers/plugins/solvers/CPLEX.py
+++ b/pyomo/solvers/plugins/solvers/CPLEX.py
@@ -520,10 +520,10 @@ class CPLEXSHELL(ILMLicensedSystemCallSolver):
         self._gap = None
 
         # use regular expressions to use multi-line match patterns:
-        self.results.solver.root_node_processing_time = get_root_node_processing_time(
+        results.solver.root_node_processing_time = get_root_node_processing_time(
             log_output=output
         )
-        self.results.solver.tree_processing_time = get_tree_processing_time(
+        results.solver.tree_processing_time = get_tree_processing_time(
             log_output=output
         )
 

--- a/pyomo/solvers/plugins/solvers/cplex_direct.py
+++ b/pyomo/solvers/plugins/solvers/cplex_direct.py
@@ -775,7 +775,7 @@ class CPLEXDirect(DirectSolver):
             if len(tokens) >= 9 and tokens[0] == "MIP" and tokens[1] == "start" and tokens[7] == "objective":
                 self.results.solver.warm_start_objective_value = float(tokens[8].rstrip('.'))
             elif line.startswith("Found incumbent of value"):
-                self.results.solver.n_solutions_found = +1
+                self.results.solver.n_solutions_found += 1
 
         if _close_log_file:
             _log_file.close()

--- a/pyomo/solvers/plugins/solvers/cplex_direct.py
+++ b/pyomo/solvers/plugins/solvers/cplex_direct.py
@@ -763,6 +763,7 @@ class CPLEXDirect(DirectSolver):
         )
 
         mip_start_warning = False
+        self.results.solver.n_solutions_found = 0
         for line in log_output.split("\n"):
             if (
                     line.startswith('Warning')
@@ -773,8 +774,8 @@ class CPLEXDirect(DirectSolver):
             tokens = re.split('[ \t]+', line.strip())
             if len(tokens) >= 9 and tokens[0] == "MIP" and tokens[1] == "start" and tokens[7] == "objective":
                 self.results.solver.warm_start_objective_value = float(tokens[8].rstrip('.'))
-            elif len(tokens) >= 5 and tokens[0:2] == ["Solution", "pool:"] and tokens[3] in ["solution", "solutions"] and tokens[4] == "saved.":
-                self.results.solver.n_solutions_found = int(tokens[2])
+            elif line.startswith("Found incumbent of value"):
+                self.results.solver.n_solutions_found = +1
 
         if _close_log_file:
             _log_file.close()

--- a/pyomo/solvers/plugins/solvers/cplex_direct.py
+++ b/pyomo/solvers/plugins/solvers/cplex_direct.py
@@ -760,6 +760,10 @@ class CPLEXDirect(DirectSolver):
                 mip_start_warning = True
                 break
 
+            tokens = re.split('[ \t]+', line.strip())
+            if len(tokens) >= 9 and tokens[0] == "MIP" and tokens[1] == "start" and tokens[7] == "objective":
+                self.results.solver.warm_start_objective_value = float(tokens[8].rstrip('.'))
+
         if _close_log_file:
             _log_file.close()
 

--- a/pyomo/solvers/plugins/solvers/cplex_direct.py
+++ b/pyomo/solvers/plugins/solvers/cplex_direct.py
@@ -763,6 +763,7 @@ class CPLEXDirect(DirectSolver):
             tokens = re.split('[ \t]+', line.strip())
             if len(tokens) >= 9 and tokens[0] == "MIP" and tokens[1] == "start" and tokens[7] == "objective":
                 self.results.solver.warm_start_objective_value = float(tokens[8].rstrip('.'))
+                break
 
         if _close_log_file:
             _log_file.close()

--- a/pyomo/solvers/plugins/solvers/cplex_direct.py
+++ b/pyomo/solvers/plugins/solvers/cplex_direct.py
@@ -769,12 +769,12 @@ class CPLEXDirect(DirectSolver):
                     and re.search(r'No solution found from \d+ MIP starts', line)
             ):
                 mip_start_warning = True
-                break
 
             tokens = re.split('[ \t]+', line.strip())
             if len(tokens) >= 9 and tokens[0] == "MIP" and tokens[1] == "start" and tokens[7] == "objective":
                 self.results.solver.warm_start_objective_value = float(tokens[8].rstrip('.'))
-                break
+            elif len(tokens) >= 5 and tokens[0:2] == ["Solution", "pool:"] and tokens[3] in ["solution", "solutions"] and tokens[4] == "saved.":
+                self.results.solver.n_solutions_found = int(tokens[2])
 
         if _close_log_file:
             _log_file.close()

--- a/pyomo/solvers/plugins/solvers/cplex_direct.py
+++ b/pyomo/solvers/plugins/solvers/cplex_direct.py
@@ -18,6 +18,7 @@ from pyomo.core.base import Suffix, Var, Constraint, SOSConstraint, Objective
 from pyomo.core.expr.numvalue import is_fixed
 from pyomo.core.expr.numvalue import value
 from pyomo.repn import generate_standard_repn
+from pyomo.solvers.plugins.solvers.cplex_helpers import get_tree_processing_time, get_root_node_processing_time
 from pyomo.solvers.plugins.solvers.direct_solver import DirectSolver
 from pyomo.solvers.plugins.solvers.direct_or_persistent_solver import DirectOrPersistentSolver
 from pyomo.core.kernel.objective import minimize, maximize
@@ -185,7 +186,7 @@ class CPLEXDirect(DirectSolver):
             self._solver_model.set_error_stream(*_log_file)
             if self._keepfiles:
                 print("Solver log file: "+self._log_file)
-            
+
             obj_degree = self._objective.expr.polynomial_degree()
             if obj_degree is None or obj_degree > 2:
                 raise DegreeError('CPLEXDirect does not support expressions of degree {0}.'\
@@ -194,21 +195,21 @@ class CPLEXDirect(DirectSolver):
                 quadratic_objective = True
             else:
                 quadratic_objective = False
-            
+
             num_integer_vars = self._solver_model.variables.get_num_integer()
             num_binary_vars = self._solver_model.variables.get_num_binary()
             num_sos = self._solver_model.SOS.get_num()
-            
+
             if self._solver_model.quadratic_constraints.get_num() != 0:
                 quadratic_cons = True
             else:
                 quadratic_cons = False
-            
+
             if (num_integer_vars + num_binary_vars + num_sos) > 0:
                 integer = True
             else:
                 integer = False
-            
+
             if integer:
                 if quadratic_cons:
                     self._solver_model.set_problem_type(self._solver_model.problem_type.MIQCP)
@@ -228,7 +229,7 @@ class CPLEXDirect(DirectSolver):
             # set cplex's mip.tolerances.mipgap
             if self.options.mipgap is not None:
                 self._solver_model.parameters.mip.tolerances.mipgap.set(float(self.options.mipgap))
-            
+
             for key, option in self.options.items():
                 if key == 'mipgap': # handled above
                     continue
@@ -747,12 +748,22 @@ class CPLEXDirect(DirectSolver):
         if self.version() >= (12, 5, 1) and isinstance(self._log_file, str):
             _log_file = open(self._log_file, 'r')
             _close_log_file = True
+            log_output: str = "".join(_log_file.readlines())
         else:
             _log_file = self._log_file
             _close_log_file = False
+            log_output: str = ""
+
+        # use regular expressions to use multi-line match patterns:
+        self.results.solver.root_node_processing_time = get_root_node_processing_time(
+            log_output=log_output
+        )
+        self.results.solver.tree_processing_time = get_tree_processing_time(
+            log_output=log_output
+        )
 
         mip_start_warning = False
-        for line in _log_file:
+        for line in log_output.split("\n"):
             if (
                     line.startswith('Warning')
                     and re.search(r'No solution found from \d+ MIP starts', line)

--- a/pyomo/solvers/plugins/solvers/cplex_helpers.py
+++ b/pyomo/solvers/plugins/solvers/cplex_helpers.py
@@ -1,0 +1,23 @@
+import re
+from typing import Optional, List
+
+
+def get_root_node_processing_time(log_output: str) -> Optional[float]:
+    # use regular expressions to use multi-line match patterns:
+    root_node_processing_time = re.search(
+        r"Root node processing.*:\n\s+Real time\s+=\s+(\d+\.\d+) sec", log_output
+    )
+    if root_node_processing_time:
+        return float(root_node_processing_time.group(1))
+    return None
+
+
+def get_tree_processing_time(log_output: str) -> Optional[float]:
+    tree_processing_time = re.search(
+        r"(?:Parallel|Sequential).*\n\s+Real time\s+=\s+(\d+\.\d+) sec", log_output
+    )
+    if tree_processing_time:
+        return float(tree_processing_time.group(1))
+    return None
+
+


### PR DESCRIPTION
## Summary/Motivation:
ENG-2369

## Changes proposed in this PR:
- Introduce two helpers methods to obtain root_node and tree processing times. These use regex matching on the full log output and are shared between direct and shell cplex solvers.
- Changes in `cplex_direct.py` to capture `tree_processing_time`, `root_node_processing_time` and `warm_start_objective_value` from the logs. Note that CPLEX versions before 12.5.1 were already not capturing log info (e.g. `mip_start_failed`).

### Legal Acknowledgement

By contributing to this software project, I have read the [contribution guide](https://pyomo.readthedocs.io/en/stable/contribution_guide.html) and agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
