### PR TITLE
Handle passing paramsets as a kwarg into solve method of cplex solver…

### DIFF
--- a/pyomo/opt/base/solvers.py
+++ b/pyomo/opt/base/solvers.py
@@ -657,6 +657,7 @@ class OptSolver(object):
         self._tee                     = kwds.pop("tee", False)
         self._assert_available        = kwds.pop("available", True)
         self._suffixes                = kwds.pop("suffixes", [])
+        kwds.pop('paramsets', None)
 
         self.available()
 

--- a/pyomo/solvers/plugins/solvers/CPLEX.py
+++ b/pyomo/solvers/plugins/solvers/CPLEX.py
@@ -306,7 +306,6 @@ class CPLEXSHELL(ILMLicensedSystemCallSolver):
             self, kwds.pop('warmstart_file', None), "warm start")
         user_warmstart = self._warm_start_file_name is not None
         self._integer_only_warmstarts = kwds.pop('integer_only_warmstarts', False)
-        kwds.pop('paramsets', None)
 
         # the input argument can currently be one of two things: an instance or a filename.
         # if a filename is provided and a warm-start is indicated, we go ahead and

--- a/pyomo/solvers/plugins/solvers/CPLEX.py
+++ b/pyomo/solvers/plugins/solvers/CPLEX.py
@@ -306,6 +306,7 @@ class CPLEXSHELL(ILMLicensedSystemCallSolver):
             self, kwds.pop('warmstart_file', None), "warm start")
         user_warmstart = self._warm_start_file_name is not None
         self._integer_only_warmstarts = kwds.pop('integer_only_warmstarts', False)
+        kwds.pop('paramsets', None)
 
         # the input argument can currently be one of two things: an instance or a filename.
         # if a filename is provided and a warm-start is indicated, we go ahead and

--- a/pyomo/solvers/plugins/solvers/cplex_direct.py
+++ b/pyomo/solvers/plugins/solvers/cplex_direct.py
@@ -672,6 +672,7 @@ class CPLEXDirect(DirectSolver):
             rtn_codes.optimal,
             rtn_codes.MIP_optimal,
             rtn_codes.optimal_tolerance,
+            rtn_codes.multiobj_optimal,
         }:
             self.results.solver.status = SolverStatus.ok
             self.results.solver.termination_condition = TerminationCondition.optimal
@@ -682,6 +683,7 @@ class CPLEXDirect(DirectSolver):
             rtn_codes.MIP_unbounded,
             rtn_codes.relaxation_unbounded,
             134,
+            rtn_codes.multiobj_unbounded,
         }:
             self.results.solver.status = SolverStatus.warning
             self.results.solver.termination_condition = TerminationCondition.unbounded
@@ -690,6 +692,7 @@ class CPLEXDirect(DirectSolver):
             rtn_codes.infeasible_or_unbounded,
             rtn_codes.MIP_infeasible_or_unbounded,
             134,
+            rtn_codes.multiobj_inforunbd,
         }:
             # Note: status of 4 means infeasible or unbounded
             #       and 119 means MIP infeasible or unbounded
@@ -697,7 +700,7 @@ class CPLEXDirect(DirectSolver):
             self.results.solver.termination_condition = \
                 TerminationCondition.infeasibleOrUnbounded
             soln.status = SolutionStatus.unsure
-        elif status in {rtn_codes.infeasible, rtn_codes.MIP_infeasible}:
+        elif status in {rtn_codes.infeasible, rtn_codes.MIP_infeasible, rtn_codes.multiobj_infeasible}:
             self.results.solver.status = SolverStatus.warning
             self.results.solver.termination_condition = TerminationCondition.infeasible
             soln.status = SolutionStatus.infeasible
@@ -722,7 +725,9 @@ class CPLEXDirect(DirectSolver):
             rtn_codes.abort_dettime_limit,
             rtn_codes.MIP_time_limit_feasible,
             rtn_codes.MIP_dettime_limit_feasible,
-        }:
+            rtn_codes.multiobj_stopped,
+            rtn_codes.multiobj_non_optimal,
+        } and cpxprob.solution.get_solution_type() != cpxprob.solution.type.none:
             self.results.solver.status = SolverStatus.aborted
             self.results.solver.termination_condition = TerminationCondition.maxTimeLimit
             soln.status = SolutionStatus.stoppedByLimit
@@ -732,6 +737,7 @@ class CPLEXDirect(DirectSolver):
             rtn_codes.node_limit_infeasible,
             rtn_codes.mem_limit_infeasible,
             rtn_codes.MIP_abort_infeasible,
+            rtn_codes.multiobj_stopped,
         } or self._error_code == self._cplex.exceptions.error_codes.CPXERR_NO_SOLN:
             # CPLEX doesn't have a solution status for `noSolution` so we assume this from the combination of
             # maxTimeLimit + infeasible (instead of a generic `TerminationCondition.error`).

--- a/pyomo/solvers/plugins/solvers/cplex_direct.py
+++ b/pyomo/solvers/plugins/solvers/cplex_direct.py
@@ -156,6 +156,8 @@ class CPLEXDirect(DirectSolver):
         self._capabilities.sos1 = True
         self._capabilities.sos2 = True
 
+        self.paramsets = None
+
     def _apply_solver(self):
         if not self._save_results:
             for block in self._pyomo_model.block_data_objects(descend_into=True, active=True):
@@ -260,7 +262,7 @@ class CPLEXDirect(DirectSolver):
             det0 = self._solver_model.get_dettime()
 
             try:
-                self._solver_model.solve()
+                self._solver_model.solve(paramsets=self.paramsets)
             except self._cplex.exceptions.CplexSolverError as e:
                 self._error_code = e.args[2]  # See cplex.exceptions.error_codes
 

--- a/pyomo/solvers/plugins/solvers/cplex_persistent.py
+++ b/pyomo/solvers/plugins/solvers/cplex_persistent.py
@@ -46,6 +46,10 @@ class CPLEXPersistent(PersistentSolver, CPLEXDirect):
         if self._pyomo_model is not None:
             self.set_instance(self._pyomo_model, **kwds)
 
+    def _presolve(self, **kwds):
+        self.paramsets = kwds.pop('paramsets', None)
+        PersistentSolver._presolve(self, **kwds)
+
     def _remove_constraint(self, solver_con):
         try:
             self._solver_model.linear_constraints.delete(solver_con)


### PR DESCRIPTION
## Fixes # .

## Summary/Motivation:
Allows passing paramsets into solve method of Pyomo for cplex solvers. Only actually used by cplex_persistent as it uses the Cplex Python API for multi-objective problemts


## Changes proposed in this PR:
-
-

### Legal Acknowledgement

By contributing to this software project, I have read the [contribution guide](https://pyomo.readthedocs.io/en/stable/contribution_guide.html) and agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
