### PR TITLE
read ticks per second from cplex logs

### DIFF
--- a/pyomo/opt/results/solver.py
+++ b/pyomo/opt/results/solver.py
@@ -202,6 +202,7 @@ class SolverInformation(MapContainer):
         self.declare('message')
         self.declare('user_time', type=ScalarType.time)
         self.declare('deterministic_time', type=ScalarType.float)
+        self.declare('ticks_per_second', type=ScalarType.float)
         self.declare('system_time', type=ScalarType.time)
         self.declare('wallclock_time', type=ScalarType.time)
         # Semantics: The specific condition that caused the solver to

--- a/pyomo/solvers/plugins/solvers/CPLEX.py
+++ b/pyomo/solvers/plugins/solvers/CPLEX.py
@@ -594,6 +594,7 @@ class CPLEXSHELL(ILMLicensedSystemCallSolver):
                 results.solver.user_time = float(tokens[3])
             elif len(tokens) >= 4 and tokens[0] == "Deterministic" and tokens[1] == "time" and tokens[2] == "=":
                 results.solver.deterministic_time = float(tokens[3])
+                results.solver.ticks_per_second = float(tokens[5][1:])
             elif len(tokens) >= 4 and tokens[0] == "Primal" and tokens[1] == "simplex" and tokens[3] == "Optimal:":
                 results.solver.termination_condition = TerminationCondition.optimal
                 results.solver.termination_message = ' '.join(tokens)

--- a/pyomo/solvers/tests/checks/test_cplex.py
+++ b/pyomo/solvers/tests/checks/test_cplex.py
@@ -442,6 +442,7 @@ CPLEX>"""
             results.solver.termination_condition, TerminationCondition.maxTimeLimit
         )
         self.assertEqual(results.solver.deterministic_time, 100.00)
+        self.assertEqual(results.solver.ticks_per_second, 10.0)
 
     def test_log_file_shows_max_deterministic_time_limit_exceeded_with_feasible_solution(self):
         log_file_text = """
@@ -461,6 +462,8 @@ CPLEX>"""
             results.solver.termination_condition, TerminationCondition.maxTimeLimit
         )
         self.assertEqual(results.solver.deterministic_time, 100.00)
+        self.assertEqual(results.solver.ticks_per_second, 10.0)
+
 
     def test_log_file_shows_warm_start_objective_value(self):
         log_file_text = """


### PR DESCRIPTION
## Fixes # .

## Summary/Motivation:
Parses ticks/second fro CPLEX logs. Used to be save in optimisation solve metrics table for reporting in grafana

## Changes proposed in this PR:
-
-

### Legal Acknowledgement

By contributing to this software project, I have read the [contribution guide](https://pyomo.readthedocs.io/en/stable/contribution_guide.html) and agree to the following terms and conditions for my contribution:

1. I agree my contributions are submitted under the BSD license.
2. I represent I am authorized to make the contributions and grant the license. If my employer has rights to intellectual property that includes these contributions, I represent that I have received permission to make contributions and grant the required license on behalf of that employer.
